### PR TITLE
fix: remove redundant grid header cell right border

### DIFF
--- a/apps/statgpt-admin-frontend/src/scss/grid.scss
+++ b/apps/statgpt-admin-frontend/src/scss/grid.scss
@@ -28,6 +28,10 @@
           @apply bg-layer-1 #{!important};
           @apply border-r border-solid border-primary #{!important};
         }
+
+        &::after {
+          @apply border-0;
+        }
       }
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

before:
<img width="495" height="196" alt="image" src="https://github.com/user-attachments/assets/5bf3c049-2330-4135-b46d-6c479c429832" />

after:
<img width="490" height="172" alt="image" src="https://github.com/user-attachments/assets/691c59ec-e838-4772-96d1-3e48205ebbc8" />


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
