### PR TITLE
fix: prevent HTML content-type responses from BFF API endpoints

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/[[...path]]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/[[...path]]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+const notFoundResponse = () =>
+  NextResponse.json({ error: 'Not Found' }, { status: 404 });
+
+export function GET() {
+  return notFoundResponse();
+}
+
+export function POST() {
+  return notFoundResponse();
+}
+
+export function PUT() {
+  return notFoundResponse();
+}
+
+export function DELETE() {
+  return notFoundResponse();
+}
+
+export function PATCH() {
+  return notFoundResponse();
+}
+
+export function OPTIONS() {
+  return notFoundResponse();
+}

--- a/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/[id]/route.ts
@@ -6,9 +6,13 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await auditLogsApi.getAuditLogById(params.id, token);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await auditLogsApi.getAuditLogById(params.id, token);
 
-  return Response.json(data);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/export/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/export/route.ts
@@ -6,10 +6,14 @@ import { mapSearchParamsToAuditLogRequest } from '@/src/utils/audit-logs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req });
+  try {
+    const token = await getToken({ req });
 
-  const { searchParams } = new URL(req.url);
-  const params = mapSearchParamsToAuditLogRequest(searchParams);
+    const { searchParams } = new URL(req.url);
+    const params = mapSearchParamsToAuditLogRequest(searchParams);
 
-  return await auditLogsApi.export(token, params);
+    return await auditLogsApi.export(token, params);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/route.ts
@@ -6,11 +6,15 @@ import { mapSearchParamsToAuditLogRequest } from '@/src/utils/audit-logs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req });
+  try {
+    const token = await getToken({ req });
 
-  const { searchParams } = new URL(req.url);
-  const params = mapSearchParamsToAuditLogRequest(searchParams);
-  const data = await auditLogsApi.getAuditLogs(token, params);
+    const { searchParams } = new URL(req.url);
+    const params = mapSearchParamsToAuditLogRequest(searchParams);
+    const data = await auditLogsApi.getAuditLogs(token, params);
 
-  return Response.json(data);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/reload-indicators/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/reload-indicators/route.ts
@@ -8,8 +8,12 @@ export async function POST(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await channelsApi.reloadDataSets(params.id, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await channelsApi.reloadDataSets(params.id, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/route.ts
@@ -3,6 +3,10 @@ import { channelsApi } from '../../../../api';
 import { getToken } from 'next-auth/jwt';
 
 export const dynamic = 'force-dynamic';
+interface ChannelDatasetPayload {
+  dsId?: string;
+  isReload?: boolean;
+}
 
 export async function GET(
   req: NextRequest,
@@ -31,7 +35,17 @@ export async function POST(
 ) {
   const params = await context.params;
   const token = await getToken({ req });
-  const res = await req.json();
+  let res: ChannelDatasetPayload;
+  try {
+    res = (await req.json()) as ChannelDatasetPayload;
+  } catch {
+    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  if (!res.dsId) {
+    return Response.json({ error: 'Missing field: dsId' }, { status: 400 });
+  }
+
   const data = res.isReload
     ? await channelsApi.reloadDataSet(params.id, res.dsId, token)
     : await channelsApi.addChannelDataset(params.id, res.dsId, token);

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/route.ts
@@ -12,42 +12,54 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await channelsApi.getChannelDataset(params.id, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await channelsApi.getChannelDataset(params.id, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const [id, dsId] = params.id.split('__');
-  const data = await channelsApi.removeChannelDataset(id, dsId, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const [id, dsId] = params.id.split('__');
+    const data = await channelsApi.removeChannelDataset(id, dsId, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }
 
 export async function POST(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  let res: ChannelDatasetPayload;
   try {
-    res = (await req.json()) as ChannelDatasetPayload;
+    const params = await context.params;
+    const token = await getToken({ req });
+    let res: ChannelDatasetPayload;
+    try {
+      res = (await req.json()) as ChannelDatasetPayload;
+    } catch {
+      return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+
+    if (!res.dsId) {
+      return Response.json({ error: 'Missing field: dsId' }, { status: 400 });
+    }
+
+    const data = res.isReload
+      ? await channelsApi.reloadDataSet(params.id, res.dsId, token)
+      : await channelsApi.addChannelDataset(params.id, res.dsId, token);
+    return Response.json(data);
   } catch {
-    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
-
-  if (!res.dsId) {
-    return Response.json({ error: 'Missing field: dsId' }, { status: 400 });
-  }
-
-  const data = res.isReload
-    ? await channelsApi.reloadDataSet(params.id, res.dsId, token)
-    : await channelsApi.addChannelDataset(params.id, res.dsId, token);
-  return Response.json(data);
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/route.ts
@@ -9,20 +9,28 @@ export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await channelsApi.removeChannel(params.id, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await channelsApi.removeChannel(params.id, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }
 
 export async function POST(req: NextRequest) {
-  let res: Channel;
   try {
-    res = (await req.json()) as Channel;
+    let res: Channel;
+    try {
+      res = (await req.json()) as Channel;
+    } catch {
+      return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+    const token = await getToken({ req });
+    const data = await channelsApi.updateChannel(res, token);
+    return Response.json(data);
   } catch {
-    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
-  const token = await getToken({ req });
-  const data = await channelsApi.updateChannel(res, token);
-  return Response.json(data);
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { channelsApi } from '../../../api';
 import { getToken } from 'next-auth/jwt';
+import { Channel } from '@/src/models/channel';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,7 +16,12 @@ export async function DELETE(
 }
 
 export async function POST(req: NextRequest) {
-  const res = await req.json();
+  let res: Channel;
+  try {
+    res = (await req.json()) as Channel;
+  } catch {
+    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
   const token = await getToken({ req });
   const data = await channelsApi.updateChannel(res, token);
   return Response.json(data);

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/download/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/download/[id]/route.ts
@@ -6,7 +6,11 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  return (await channelsApi.downloadFile(params.id, token)) as any;
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    return (await channelsApi.downloadFile(params.id, token)) as any;
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/import/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/import/route.ts
@@ -5,19 +5,23 @@ import { channelsApi } from '@/src/app/api/api';
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
-  const formData = await req.formData();
-  const search = req.nextUrl.searchParams;
-  const updateDatasets = search.get('updateDatasets') === 'true';
-  const updateDataSources = search.get('updateDataSources') === 'true';
-  const cleanUp = search.get('cleanUp') === 'true';
-  const token = await getToken({ req });
-  const res = await channelsApi.importChannel(
-    formData,
-    updateDatasets,
-    updateDataSources,
-    cleanUp,
-    token,
-  );
+  try {
+    const formData = await req.formData();
+    const search = req.nextUrl.searchParams;
+    const updateDatasets = search.get('updateDatasets') === 'true';
+    const updateDataSources = search.get('updateDataSources') === 'true';
+    const cleanUp = search.get('cleanUp') === 'true';
+    const token = await getToken({ req });
+    const res = await channelsApi.importChannel(
+      formData,
+      updateDatasets,
+      updateDataSources,
+      cleanUp,
+      token,
+    );
 
-  return NextResponse.json(res);
+    return NextResponse.json(res);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/data-sources/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/data-sources/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { dataSourcesApi } from '../../../api';
 import { getToken } from 'next-auth/jwt';
+import { DataSource } from '@/src/models/data-source';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +17,12 @@ export async function DELETE(
 
 export async function POST(req: NextRequest) {
   const token = await getToken({ req });
-  const res = await req.json();
+  let res: DataSource;
+  try {
+    res = (await req.json()) as DataSource;
+  } catch {
+    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
   const data = await dataSourcesApi.updateDataSources(res, token);
   return Response.json(data);
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/data-sources/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/data-sources/[id]/route.ts
@@ -9,20 +9,28 @@ export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await dataSourcesApi.removeDataSource(params.id, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await dataSourcesApi.removeDataSource(params.id, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }
 
 export async function POST(req: NextRequest) {
-  const token = await getToken({ req });
-  let res: DataSource;
   try {
-    res = (await req.json()) as DataSource;
+    const token = await getToken({ req });
+    let res: DataSource;
+    try {
+      res = (await req.json()) as DataSource;
+    } catch {
+      return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+    const data = await dataSourcesApi.updateDataSources(res, token);
+    return Response.json(data);
   } catch {
-    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
-  const data = await dataSourcesApi.updateDataSources(res, token);
-  return Response.json(data);
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/reload-dimensions/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/reload-dimensions/route.ts
@@ -8,8 +8,12 @@ export async function POST(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await dataSetsApi.reloadDimensionsDataSet(params.id, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await dataSetsApi.reloadDimensionsDataSet(params.id, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { dataSetsApi } from '../../../api';
 import { getToken } from 'next-auth/jwt';
+import { DataSet } from '@/src/models/data-sets';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +17,12 @@ export async function DELETE(
 
 export async function POST(req: NextRequest) {
   const token = await getToken({ req });
-  const res = await req.json();
+  let res: DataSet;
+  try {
+    res = (await req.json()) as DataSet;
+  } catch {
+    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
   const data = await dataSetsApi.updateDataSet(res, token);
   return Response.json(data);
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/route.ts
@@ -9,20 +9,28 @@ export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  const data = await dataSetsApi.removeDataSet(params.id, token);
-  return Response.json(data);
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    const data = await dataSetsApi.removeDataSet(params.id, token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }
 
 export async function POST(req: NextRequest) {
-  const token = await getToken({ req });
-  let res: DataSet;
   try {
-    res = (await req.json()) as DataSet;
+    const token = await getToken({ req });
+    let res: DataSet;
+    try {
+      res = (await req.json()) as DataSet;
+    } catch {
+      return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+    const data = await dataSetsApi.updateDataSet(res, token);
+    return Response.json(data);
   } catch {
-    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
-  const data = await dataSetsApi.updateDataSet(res, token);
-  return Response.json(data);
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/route.ts
@@ -5,7 +5,11 @@ import { getToken } from 'next-auth/jwt';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req });
-  const data = await dataSetsApi.getDataSets(token);
-  return Response.json(data);
+  try {
+    const token = await getToken({ req });
+    const data = await dataSetsApi.getDataSets(token);
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/download/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/download/[id]/route.ts
@@ -6,7 +6,11 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
-  const params = await context.params;
-  const token = await getToken({ req });
-  return (await channelsApi.downloadFile(params.id, token)) as any;
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    return (await channelsApi.downloadFile(params.id, token)) as any;
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/download/import/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/download/import/route.ts
@@ -4,10 +4,14 @@ import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
-  const formData = await req.formData();
-  const search = req.nextUrl.searchParams;
-  const targetPath = search.get('targetPath') as string;
+  try {
+    const formData = await req.formData();
+    const search = req.nextUrl.searchParams;
+    const targetPath = search.get('targetPath') as string;
 
-  const res = await documentsApi.uploadFile(formData, targetPath);
-  return NextResponse.json(res);
+    const res = await documentsApi.uploadFile(formData, targetPath);
+    return NextResponse.json(res);
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -7,6 +7,7 @@ export const API = 'api/v1';
 export const MAIN_API = `${ADMIN}/${API}`;
 
 export const CACHE: RequestInit = { cache: 'no-store' };
+const PREVIEW_BODY_LENGTH = 1000;
 
 export const sendPostRequest = <T extends object, R>(
   url: string,
@@ -53,6 +54,20 @@ export const streamRequest = async (
       },
     });
 
+    const contentType = res.headers.get('content-type');
+    if (!res.ok && contentType?.toLowerCase().includes('text/html')) {
+      const bodyPreview = (await res.text()).slice(0, PREVIEW_BODY_LENGTH);
+      console.error(
+        'Proxy error: Unexpected HTML response from upstream',
+        res.status,
+        bodyPreview,
+      );
+      return Response.json(
+        { error: 'Unexpected HTML response from upstream service' },
+        { status: 502 },
+      );
+    }
+
     const headers = new Headers(res.headers);
 
     return new Response(res.body, {
@@ -62,7 +77,7 @@ export const streamRequest = async (
     });
   } catch (e) {
     console.error('Error', e);
-    return new Response('Proxy error', { status: 500 });
+    return Response.json({ error: 'Proxy error' }, { status: 500 });
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "ag-grid-community": "^34.1.0",
         "ag-grid-react": "^34.1.0",
         "classnames": "^2.5.1",
-        "lodash": "^4.17.23",
-        "next": "15.5.14",
+        "lodash": "^4.18.1",
+        "next": "^15.5.15",
         "next-auth": "^4.24.12",
         "pino": "^10.1.0",
         "pino-pretty": "^13.1.2",
@@ -5835,16 +5835,16 @@
       }
     },
     "node_modules/@module-federation/node": {
-      "version": "2.7.39",
-      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.39.tgz",
-      "integrity": "sha512-BsfpXVIuNO5KBwvOKaTuSK4jU+vrWcDvrue2K+3YGY8lUL7mwx11W4TP4Dvrslazub93zz5NBM44qqogo+VGXA==",
+      "version": "2.7.41",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.41.tgz",
+      "integrity": "sha512-ZaNrfX+7ua8UvnRa6qgrDtViU9Oz3oBGpFprldU8ek0NB2QWNACu9RMU7fHdTD/FKlzGVLi/LgdKnNKkmJD2TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "2.3.1",
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "encoding": "^0.1.13",
+        "@module-federation/enhanced": "2.3.3",
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "encoding": "0.1.13",
         "node-fetch": "2.7.0",
         "tapable": "2.3.0"
       },
@@ -5858,27 +5858,26 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.1.tgz",
-      "integrity": "sha512-rixIHit2xeusr052t/IOfgQa9OyKc21GiJC8uE/5szmgJlJOHmiXa7QrudKb4KVDCcbd5Ad2b4+XrSYxxRUzJA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.3.tgz",
+      "integrity": "sha512-W2jQ3Wuqree9Dq3UAx8jGbYtvHuuYgzrd2j9FP8Bt6NaynaNU1yYG86MBnAhZJPTltex0CguudR1dgFpYdvLUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.3.1",
+        "@module-federation/sdk": "2.3.3",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.1.tgz",
-      "integrity": "sha512-9oUqFuXaZgUc1ptBPKLIUmKrzu0kog1kE05BLMEUm55JkiDtODpuzQhT/QL8h0qHBeZ70Rn12ARQQBmoZT61Aw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.3.tgz",
+      "integrity": "sha512-g3f3aEruv07zK4VcUlAllswrp2ncA/jF0P0yoEWNRa9K7N+xNCfqcdzw2aVWOJ30qNMurhLWuyzYqfDIx0LpfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -5890,15 +5889,14 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/data-prefetch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.1.tgz",
-      "integrity": "sha512-p/G5Nlu7buiE7TdrznHanxFS1Zik8nmzNUDLmgwfdHRIaH7Rj4+gLIgLg5Zrjtkdvae/L2UJpcC8QopJMQjv4A==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.3.tgz",
+      "integrity": "sha512-ZM1QtyjbWYnhUizHFhwYjHGXlkZek3vzTpL35d5FkAhVrOU0u0Qv6zpZjdcCm0FJznqVsUQx1w0vagUyGWQf0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "fs-extra": "9.1.0"
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -5914,22 +5912,21 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/dts-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.1.tgz",
-      "integrity": "sha512-6BJvu+dLDtW/ngpyuOLgpKOgtOnMUTZY51JUyargVckerKRbe7Ul+414YaHj32mu2FpsiHVMl4ig1XnxgnRg2Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.3.tgz",
+      "integrity": "sha512-VNtURt+hvieNKCBleAqHKffLAU4clKmuuqLQIbvDkFbGe4bo7hUaq5DruTnJBWWDOizZx0OQrdQYPijCnBK6UQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "@module-federation/third-party-dts-extractor": "2.3.1",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "1.13.5",
-        "fs-extra": "9.1.0",
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "@module-federation/third-party-dts-extractor": "2.3.3",
+        "adm-zip": "0.5.10",
+        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
+        "undici": "7.24.7",
         "ws": "8.18.0"
       },
       "peerDependencies": {
@@ -5943,25 +5940,25 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/enhanced": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.1.tgz",
-      "integrity": "sha512-zvzymtzsYVlSPt/HKjm42OGiDxUDPLce7mr6VZw4d6//AFFK3kKUEpUqwlf/bIlbg7FbwJC/7hVCmUhlF+dxgw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.3.tgz",
+      "integrity": "sha512-BJSs56lqO9NI9aC+hVhg2CU/UwG1TphVl1b7WBx6Jv6DYUyVQbgXeQpgqYVsxYVRKYOl7eDZmjXl2eA/n1IP/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.3.1",
-        "@module-federation/cli": "2.3.1",
-        "@module-federation/data-prefetch": "2.3.1",
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/inject-external-runtime-core-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/manifest": "2.3.1",
-        "@module-federation/rspack": "2.3.1",
-        "@module-federation/runtime-tools": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "@module-federation/webpack-bundler-runtime": "2.3.1",
-        "schema-utils": "^4.3.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.3.3",
+        "@module-federation/cli": "2.3.3",
+        "@module-federation/data-prefetch": "2.3.3",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/inject-external-runtime-core-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/manifest": "2.3.3",
+        "@module-federation/rspack": "2.3.3",
+        "@module-federation/runtime-tools": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "@module-federation/webpack-bundler-runtime": "2.3.3",
+        "schema-utils": "4.3.0",
         "tapable": "2.3.0",
         "upath": "2.0.1"
       },
@@ -5986,62 +5983,60 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/error-codes": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.1.tgz",
-      "integrity": "sha512-s3IjT2OYrSBNNmxdTmmrWBpsFfeNszdL6BSqjXLHb1CgXWUYLNXpb05IopnzMhRLcur6MTGuKR0ZSjJbmvQBbg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.3.tgz",
+      "integrity": "sha512-UVtKBoKnRDcHgByIDvPRZSxQqjqbNH7NvJm1KHLoce33+EDiIdZYs0HvvUQv43RgESpB9s7HjrqFlq3bEcAgfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.1.tgz",
-      "integrity": "sha512-Q/zd3dImx4vyXLQ/UEQ0udL95yPlfbSyKcoW86tIralxA5NgnR3rEp3ccGt9MHSBbCywFrbzX5OwfKW/Jgfexw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.3.tgz",
+      "integrity": "sha512-ImSft6hOkMdnpZX8O+RydwkYENxhAwT92n1OAT3Xf01DXMrEpSO0PqBlPGgontxuiaV9dM2/xWSLGuIWaOtupA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.3.1"
+        "@module-federation/runtime-tools": "2.3.3"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/managers": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.1.tgz",
-      "integrity": "sha512-kK/4FkoaIxbJbN+R6+cq+igv095hPox8oheZOKkrYA9P6Xv5FiHza+gHlCntiWTMrU8bzqJHH4VYm6gq1RB+dQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.3.tgz",
+      "integrity": "sha512-sYL0t2guakJ+nDSQANH54uz5q1YxaNCn5C3lr+7BoRD49dX7Z6k7094yqOPEy8trzqdIoQVFpgewVA6IC/FeyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.3.1",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
+        "@module-federation/sdk": "2.3.3",
+        "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/manifest": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.1.tgz",
-      "integrity": "sha512-BXckns3ux6Z9XiB2Bpirj/Q3FcQnxiyKt0rx0HmF0/7V6Zy2mwR/011eoeRGHN9N2HZcIxgQcWgMtxl5FAqxyg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.3.tgz",
+      "integrity": "sha512-mAEXuo5sGt8FUDzftU8f0ci0PbsZIDcLRYX9AkXwbXg0JRyVEvWyiBrEKF+zZuy7YM7eRdyp6JjLJPDzufhj5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/rspack": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.1.tgz",
-      "integrity": "sha512-pZmLSDkD7nDsCc377Q8sB1Yu2iMYFj72VS/Fb8B7uTmhYwU1wqDK9zPwaxauim5Y4TqQBdy/hPzNES3f4lG33Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.3.tgz",
+      "integrity": "sha512-4s3G+wXZ6J3rKe0EeZnGLQUM7y+qpiI5NM3U6ylZuxD8q7mAwQVHThbH6ruDYUNDVEOc6N0j/+/LdfGRw+e5xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.3.1",
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/inject-external-runtime-core-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/manifest": "2.3.1",
-        "@module-federation/runtime-tools": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/bridge-react-webpack-plugin": "2.3.3",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/inject-external-runtime-core-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/manifest": "2.3.3",
+        "@module-federation/runtime-tools": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -6058,43 +6053,43 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.1.tgz",
-      "integrity": "sha512-NiKelHKzOf1Vz8oqcxC/XRUAW224O6lKj9xD0cfp5Bp343iu6s58RlLvX1ypF+UpCl3jA4JM8npGax/3jjyifw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.3.tgz",
+      "integrity": "sha512-JYJ3qv9V85DtBtT/ppDuJNwBTUrYqqZDYcyiTzwY5+44dC5QPvgJ//F+BOhAhZ02WkZV0b4jsKTyLOC3vXKGqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/runtime-core": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/runtime-core": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/runtime-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.1.tgz",
-      "integrity": "sha512-E0WgaCn32AWzD0n6SCH7VQ+kxk46XyX432PQWARgyQzCX/wyLkaT+We3A18RVNUevRT85YHLrrVIhMKJJVHgjA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.3.tgz",
+      "integrity": "sha512-B07LDH9KxhBO3GbULGW64mQFVQBtrEd3PoaCBm7XR1IbU8rMQUJQjDNVZgXYcyhRPBVP+3KWZuiaKFRiNb6PQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/runtime-tools": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.1.tgz",
-      "integrity": "sha512-JrTKnNxIglnwrycPHUz9vARHLWqdecgFJxhmu8991z5CjktHc5JIelCbQS5Ur2lABjuwBdlyw8pH2xI3EJpbOg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.3.tgz",
+      "integrity": "sha512-XODzyLbBYcy4wnYBXKIBqaHPVfBx1HshGdjZmSctDDnx9/VYgdx9DShb6UI+WuQBKJgPzTcx4xbvbCM4SdMilQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/webpack-bundler-runtime": "2.3.1"
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/webpack-bundler-runtime": "2.3.3"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/sdk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.1.tgz",
-      "integrity": "sha512-lgWxFZyLRKDXWRGlV6ROjFJ6MRaJTxs0bBnS6hS9ONfr/0TkeW4JzDbsfzrB8g4p6IgSKB+wQ9XfibJCGBI5OQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.3.tgz",
+      "integrity": "sha512-mwCS+LQdqiSc6fM5iz/S60ibaFNSH6kNqlZkCRIuS4yjdZ+jgnihz+6xp1QzppvfFgKLhEHBiXOmcYOdk3Ckew==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6107,61 +6102,94 @@
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.1.tgz",
-      "integrity": "sha512-YpTLzM7H9damh31JX7eFBiCCR1mbibzS4i4JEa4fZ5ICT4hfNIuaAx1OeICGDOzSdl35TYegegCjk91oX6xCJQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.3.tgz",
+      "integrity": "sha512-rR94TjC1QVQLQPTazI0waLc76hI8dnv6aHTl+PUEIY9s5hXp8TA85XS0QJQqIf2KTjlPgZbWAwyFjOAJluTjaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
         "resolve": "1.22.8"
       }
     },
     "node_modules/@module-federation/node/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.1.tgz",
-      "integrity": "sha512-fnsMncVdBYv7a1gN5ElNK1uA9dmGUgaNqcoNiv9xRtpxFYswchl1kbgxPTliCb8U7quihdWZos7P2lvpYeVRwg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.3.tgz",
+      "integrity": "sha512-W+P6ZF9J3gwnQuoF07YV0OiR1D6sI/uErUu4+c3QXxka3orANUHujkddNSsDxL1obAGoJa7Da99crZKf7u2j/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
-    "node_modules/@module-federation/node/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+    "node_modules/@module-federation/node/node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@module-federation/node/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=6.0"
       }
     },
-    "node_modules/@module-federation/node/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+    "node_modules/@module-federation/node/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@module-federation/node/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/@module-federation/node/node_modules/semver": {
       "version": "7.6.3",
@@ -6307,9 +6335,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -6353,9 +6381,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -6369,9 +6397,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -6385,11 +6413,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -6401,11 +6432,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6417,11 +6451,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -6433,11 +6470,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6449,9 +6489,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -6465,9 +6505,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -7123,7 +7163,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7163,7 +7202,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7184,7 +7222,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7205,7 +7242,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7226,7 +7262,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7247,7 +7282,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7268,7 +7302,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7289,7 +7322,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7310,7 +7342,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7331,7 +7362,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7352,7 +7382,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7373,7 +7402,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7394,7 +7422,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7415,7 +7442,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10833,9 +10859,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13088,9 +13114,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -14784,9 +14810,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -16295,7 +16321,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16367,7 +16393,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -21323,12 +21349,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -21341,14 +21367,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -21474,7 +21500,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -22427,7 +22452,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -27214,6 +27239,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "ag-grid-community": "^34.1.0",
     "ag-grid-react": "^34.1.0",
     "classnames": "^2.5.1",
-    "lodash": "^4.17.23",
-    "next": "15.5.14",
+    "lodash": "^4.18.1",
+    "next": "^15.5.15",
     "next-auth": "^4.24.12",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.2",
@@ -85,7 +85,7 @@
     "minimatch": "10.2.3",
     "picomatch": "4.0.4",
     "serialize-javascript": "7.0.5",
-    "dompurify": "3.3.3"
+    "dompurify": "3.4.0"
   },
   "engines": {
     "node": ">=22.2.0",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #103 

### Description of changes

BFF streaming endpoints (/api/v1/audit-logs/export, /api/v1/channels/download/[id]) were forwarding upstream responses verbatim, including error pages with Content-Type: text/html. This fix intercepts non-2xx HTML responses in streamRequest and returns a JSON 502 error instead, so the application never exposes an HTML MIME type to clients.

Additionally, BFF route handlers now return a 400 on invalid JSON payloads rather than letting the request fail with an unhandled error.

All BFF route handlers are now wrapped in a top-level try/catch to ensure unhandled exceptions return a JSON 500 response instead of the default Next.js HTML error page. A catch-all route handler was also added so unknown /api/* paths return a JSON 404 instead of the Next.js HTML 404 page.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
