### PR TITLE
fix: add X-XSS-Protection response header

### DIFF
--- a/apps/statgpt-admin-frontend/next.config.js
+++ b/apps/statgpt-admin-frontend/next.config.js
@@ -35,6 +35,10 @@ const nextConfig = {
             value: 'nosniff',
           },
           {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
             key: 'X-Frame-Options',
             value: 'DENY',
           },


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes https://github.com/epam/statgpt-admin-frontend/issues/105

### Description of changes

Adds the X-XSS-Protection: 1; mode=block response header to address a security scan finding. The app already has a strong nonce-based CSP so this is a compliance addition with no functional impact on modern browsers.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
