### PR TITLE
fix: pass title during dataset creation and handle error

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { dataSetsApi } from '../../api';
 import { getToken } from 'next-auth/jwt';
+import { DataSet } from '@/src/models/data-sets';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,5 +12,29 @@ export async function GET(req: NextRequest) {
     return Response.json(data);
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = (await req.json()) as DataSet;
+    const token = await getToken({ req });
+    const result = await dataSetsApi.createDataSetSafe(payload, token);
+
+    if (!result.ok) {
+      return Response.json({
+        ok: false,
+        res:
+          result.error.message ||
+          'Failed to create dataset. Please check required fields.',
+      });
+    }
+
+    return Response.json({ ok: true, res: result.data });
+  } catch {
+    return Response.json({
+      ok: false,
+      res: 'Internal Server Error',
+    });
   }
 }

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
@@ -2,16 +2,18 @@ import { useRouter } from 'next/navigation';
 import { FC, useEffect, useState } from 'react';
 import { parse, stringify } from 'yaml';
 
-import { createDataSet } from '@/src/app/data-sets/actions';
 import { getDataSources } from '@/src/app/data-sources/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { Configuration } from '@/src/components/Configuration/Configuration';
 import { Modal } from '@/src/components/Modal/Modal';
 import { Stepper } from '@/src/components/Stepper/Stepper';
 import { BaseStep, DatasetStep } from '@/src/constants/steps';
+import { useNotification } from '@/src/context/NotificationContext';
 import { DataSet } from '@/src/models/data-sets';
+import { NotificationType } from '@/src/models/notification';
 import { DataSource } from '@/src/models/data-source';
 import { RequestData } from '@/src/models/request-data';
+import { sendPostRequest } from '@/src/server/api';
 import { Step } from '@/src/models/step';
 import { ModalsButtons } from './Buttons/ModalsButtons';
 import { DataSetStep } from './DataSetStep/DataSetStep';
@@ -23,6 +25,7 @@ interface Props {
 
 export const AddDataSetModal: FC<Props> = ({ close }) => {
   const router = useRouter();
+  const { showNotification } = useNotification();
   const dataSetSteps: Step[] = [
     {
       key: DatasetStep.DataSource,
@@ -55,10 +58,27 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
 
   const createDataset = () => {
     setIsLoadingDs(true);
-    createDataSet(newDataSet).then(() => {
-      router.refresh();
+    sendPostRequest<DataSet, { ok: boolean; res: DataSet | string }>(
+      '/api/v1/datasets',
+      newDataSet,
+    ).then((res) => {
       setIsLoadingDs(false);
-      close();
+      if (res?.ok) {
+        router.refresh();
+        close();
+        return;
+      }
+
+      const message =
+        typeof res?.res === 'string'
+          ? res.res
+          : 'Failed to create dataset. Please check required fields.';
+
+      showNotification({
+        type: NotificationType.error,
+        title: 'Dataset Creation Failed',
+        description: message,
+      });
     });
   };
 
@@ -88,9 +108,10 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       return (
         <DataSetStep
           selectedDataSourceId={newDataSet?.data_source_id}
-          changeDataSet={(details) =>
+          changeDataSet={({ title, details }) =>
             setDataSet({
               ...(newDataSet || {}),
+              title,
               details,
             } as DataSet)
           }
@@ -133,7 +154,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
         activeStep={activeStep}
         setActiveStep={setActiveStep}
         isValidDataSourceStep={!newDataSet?.data_source_id}
-        isValidDataSetStep={!newDataSet?.details}
+        isValidDataSetStep={!newDataSet?.details || !newDataSet?.title}
       />
     </Modal>
   );

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
@@ -10,7 +10,7 @@ import { RequestData } from '@/src/models/request-data';
 
 interface Props {
   selectedDataSourceId?: number;
-  changeDataSet: (details: Record<string, unknown>) => void;
+  changeDataSet: (dataset: Pick<DataSet, 'title' | 'details'>) => void;
 }
 
 export const DataSetStep: FC<Props> = ({
@@ -23,7 +23,10 @@ export const DataSetStep: FC<Props> = ({
   const gridOptions: GridOptions = {
     rowSelection: 'single',
     onRowSelected: (event) => {
-      changeDataSet(event.data.details);
+      changeDataSet({
+        title: event.data.title,
+        details: event.data.details,
+      });
     },
   };
 

--- a/apps/statgpt-admin-frontend/src/components/Notification/NotificationPortal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Notification/NotificationPortal.tsx
@@ -16,7 +16,7 @@ const NotificationPortal: FC<Props> = ({ notifications }) => {
   return (
     <>
       {createPortal(
-        <div className="flex flex-col fixed bottom-3 right-3 z-50">
+        <div className="flex flex-col fixed bottom-3 right-3 z-[200]">
           {notifications.map((notification) =>
             notification.type === NotificationType.dynamic ? (
               <DynamicNotification key={notification.id} {...notification} />

--- a/apps/statgpt-admin-frontend/src/server/api-error-parser.ts
+++ b/apps/statgpt-admin-frontend/src/server/api-error-parser.ts
@@ -1,0 +1,112 @@
+import type { ApiError } from './api';
+
+export const parseApiError = async (response: Response): Promise<ApiError> => {
+  const contentType = response.headers.get('content-type')?.toLowerCase() || '';
+  if (contentType.includes('application/json')) {
+    const payload = (await response.json()) as {
+      detail?: unknown;
+      message?: string;
+      error?: string;
+    };
+
+    if (typeof payload.message === 'string' && payload.message) {
+      return {
+        status: response.status,
+        message: payload.message,
+        details: payload.detail,
+        raw: payload,
+      };
+    }
+
+    if (Array.isArray(payload.detail) && payload.detail.length > 0) {
+      const validationMessage = payload.detail
+        .map((item) => formatValidationMessage(item))
+        .filter(Boolean)
+        .join('; ');
+
+      return {
+        status: response.status,
+        message: validationMessage || 'Validation failed',
+        details: payload.detail,
+        raw: payload,
+      };
+    }
+
+    if (typeof payload.detail === 'string' && payload.detail) {
+      return {
+        status: response.status,
+        message: payload.detail,
+        details: payload.detail,
+        raw: payload,
+      };
+    }
+
+    if (typeof payload.error === 'string' && payload.error) {
+      return {
+        status: response.status,
+        message: payload.error,
+        raw: payload,
+      };
+    }
+
+    return {
+      status: response.status,
+      message: `Request failed with status ${response.status}`,
+      raw: payload,
+    };
+  }
+
+  const text = await response.text();
+  return {
+    status: response.status,
+    message: text || `Request failed with status ${response.status}`,
+    raw: text,
+  };
+};
+
+const formatValidationMessage = (item: unknown): string => {
+  if (!item || typeof item !== 'object') {
+    return '';
+  }
+
+  const typedItem = item as { loc?: unknown[]; msg?: unknown; type?: unknown };
+
+  const locTokens = Array.isArray(typedItem.loc)
+    ? typedItem.loc
+        .map((token) => String(token))
+        .filter((token) => !['body', 'query', 'path'].includes(token))
+    : [];
+  const fieldName = locTokens.length > 0 ? locTokens[locTokens.length - 1] : '';
+
+  const msg = typeof typedItem.msg === 'string' ? typedItem.msg : '';
+  const errorType = typeof typedItem.type === 'string' ? typedItem.type : '';
+  const normalizedMsg = msg.toLowerCase();
+
+  if (
+    normalizedMsg.includes('field required') ||
+    normalizedMsg.includes('missing')
+  ) {
+    return fieldName
+      ? `Missing required field: ${fieldName}`
+      : 'Missing required field';
+  }
+
+  if (
+    normalizedMsg.includes('valid') ||
+    normalizedMsg.includes('invalid') ||
+    normalizedMsg.includes('type') ||
+    errorType.includes('type_error')
+  ) {
+    return fieldName ? `Invalid value for ${fieldName}` : 'Invalid value';
+  }
+
+  if (msg) {
+    return fieldName ? `${fieldName}: ${msg}` : msg;
+  }
+
+  if (fieldName) {
+    return `Validation error in ${fieldName}`;
+  }
+
+  return 'Validation error';
+};

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -179,13 +179,17 @@ export const sendRequestSafe = async <T extends object, R>(
       console.error('Request error Url', response.url);
 
       const error = await parseApiError(response);
-      console.error('Request error', response.status, error.raw || error.message);
+      console.error(
+        'Request error',
+        response.status,
+        error.raw || error.message,
+      );
       return { ok: false, error };
     }
 
-    const data = (type === 'DELETE'
-      ? await response.text()
-      : await response.json()) as R;
+    const data = (
+      type === 'DELETE' ? await response.text() : await response.json()
+    ) as R;
     return { ok: true, data };
   } catch (e) {
     console.error('Error', e);

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -1,6 +1,7 @@
 import { JWT } from 'next-auth/jwt';
 
 import { getApiHeaders } from '@/src/utils/auth/api-headers';
+import { parseApiError } from './api-error-parser';
 
 export const ADMIN = '';
 export const API = 'api/v1';
@@ -202,81 +203,4 @@ export const sendRequestSafe = async <T extends object, R>(
       },
     };
   }
-};
-
-const parseApiError = async (response: Response): Promise<ApiError> => {
-  const contentType = response.headers.get('content-type')?.toLowerCase() || '';
-  if (contentType.includes('application/json')) {
-    const payload = (await response.json()) as {
-      detail?: unknown;
-      message?: string;
-      error?: string;
-    };
-
-    if (typeof payload.message === 'string' && payload.message) {
-      return {
-        status: response.status,
-        message: payload.message,
-        details: payload.detail,
-        raw: payload,
-      };
-    }
-
-    if (Array.isArray(payload.detail) && payload.detail.length > 0) {
-      const validationMessage = payload.detail
-        .map((item) => {
-          if (!item || typeof item !== 'object') {
-            return '';
-          }
-
-          const loc = Array.isArray((item as { loc?: unknown[] }).loc)
-            ? ((item as { loc?: unknown[] }).loc as unknown[]).join('.')
-            : 'field';
-          const msg =
-            typeof (item as { msg?: unknown }).msg === 'string'
-              ? (item as { msg: string }).msg
-              : '';
-          return msg ? `${loc}: ${msg}` : '';
-        })
-        .filter(Boolean)
-        .join('; ');
-
-      return {
-        status: response.status,
-        message: validationMessage || 'Validation failed',
-        details: payload.detail,
-        raw: payload,
-      };
-    }
-
-    if (typeof payload.detail === 'string' && payload.detail) {
-      return {
-        status: response.status,
-        message: payload.detail,
-        details: payload.detail,
-        raw: payload,
-      };
-    }
-
-    if (typeof payload.error === 'string' && payload.error) {
-      return {
-        status: response.status,
-        message: payload.error,
-        raw: payload,
-      };
-    }
-
-    return {
-      status: response.status,
-      message: `Request failed with status ${response.status}`,
-      raw: payload,
-    };
-  }
-
-  const text = await response.text();
-  return {
-    status: response.status,
-    message: text || `Request failed with status ${response.status}`,
-    raw: text,
-  };
 };

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -9,6 +9,23 @@ export const MAIN_API = `${ADMIN}/${API}`;
 export const CACHE: RequestInit = { cache: 'no-store' };
 const PREVIEW_BODY_LENGTH = 1000;
 
+export interface ApiError {
+  status: number;
+  message: string;
+  details?: unknown;
+  raw?: unknown;
+}
+
+export type ApiResult<R> =
+  | {
+      ok: true;
+      data: R;
+    }
+  | {
+      ok: false;
+      error: ApiError;
+    };
+
 export const sendPostRequest = <T extends object, R>(
   url: string,
   dto?: T,
@@ -38,6 +55,30 @@ export const sendGetRequest = <T extends object, R>(
 
 export const sendDeleteRequest = <R>(url: string): Promise<R | null> => {
   return sendRequest(url, 'DELETE');
+};
+
+export const sendPostRequestSafe = <T extends object, R>(
+  url: string,
+  dto?: T,
+  qs?: Record<string, string>,
+  initHeaders?: HeadersInit,
+): Promise<ApiResult<R>> => {
+  return sendRequestSafe(url, 'POST', dto, qs, initHeaders);
+};
+
+export const sendPutRequestSafe = <T extends object, R>(
+  url: string,
+  dto?: T,
+  qs?: Record<string, string>,
+  initHeaders?: HeadersInit,
+): Promise<ApiResult<R>> => {
+  return sendRequestSafe(url, 'PUT', dto, qs, initHeaders);
+};
+
+export const sendDeleteRequestSafe = <R>(
+  url: string,
+): Promise<ApiResult<R>> => {
+  return sendRequestSafe(url, 'DELETE');
 };
 
 export const streamRequest = async (
@@ -113,4 +154,125 @@ export const sendRequest = async <T extends object, R>(
     console.error('Error', e);
     return Promise.resolve(null);
   }
+};
+
+export const sendRequestSafe = async <T extends object, R>(
+  url: string,
+  type: string,
+  dto?: T,
+  qs?: Record<string, string>,
+  initHeaders?: HeadersInit,
+  token?: JWT | null,
+): Promise<ApiResult<R>> => {
+  try {
+    const response = await fetch(url, {
+      body: dto instanceof FormData ? dto : JSON.stringify(dto),
+      method: type,
+      cache: 'no-store',
+      headers: {
+        ...initHeaders,
+        ...getApiHeaders({ jwt: token?.access_token }, dto instanceof FormData),
+      },
+    });
+
+    if (!(response.status >= 200 && response.status < 300)) {
+      console.error('Request error Url', response.url);
+
+      const error = await parseApiError(response);
+      console.error('Request error', response.status, error.raw || error.message);
+      return { ok: false, error };
+    }
+
+    const data = (type === 'DELETE'
+      ? await response.text()
+      : await response.json()) as R;
+    return { ok: true, data };
+  } catch (e) {
+    console.error('Error', e);
+    return {
+      ok: false,
+      error: {
+        status: 0,
+        message: 'Request failed',
+        raw: e,
+      },
+    };
+  }
+};
+
+const parseApiError = async (response: Response): Promise<ApiError> => {
+  const contentType = response.headers.get('content-type')?.toLowerCase() || '';
+  if (contentType.includes('application/json')) {
+    const payload = (await response.json()) as {
+      detail?: unknown;
+      message?: string;
+      error?: string;
+    };
+
+    if (typeof payload.message === 'string' && payload.message) {
+      return {
+        status: response.status,
+        message: payload.message,
+        details: payload.detail,
+        raw: payload,
+      };
+    }
+
+    if (Array.isArray(payload.detail) && payload.detail.length > 0) {
+      const validationMessage = payload.detail
+        .map((item) => {
+          if (!item || typeof item !== 'object') {
+            return '';
+          }
+
+          const loc = Array.isArray((item as { loc?: unknown[] }).loc)
+            ? ((item as { loc?: unknown[] }).loc as unknown[]).join('.')
+            : 'field';
+          const msg =
+            typeof (item as { msg?: unknown }).msg === 'string'
+              ? (item as { msg: string }).msg
+              : '';
+          return msg ? `${loc}: ${msg}` : '';
+        })
+        .filter(Boolean)
+        .join('; ');
+
+      return {
+        status: response.status,
+        message: validationMessage || 'Validation failed',
+        details: payload.detail,
+        raw: payload,
+      };
+    }
+
+    if (typeof payload.detail === 'string' && payload.detail) {
+      return {
+        status: response.status,
+        message: payload.detail,
+        details: payload.detail,
+        raw: payload,
+      };
+    }
+
+    if (typeof payload.error === 'string' && payload.error) {
+      return {
+        status: response.status,
+        message: payload.error,
+        raw: payload,
+      };
+    }
+
+    return {
+      status: response.status,
+      message: `Request failed with status ${response.status}`,
+      raw: payload,
+    };
+  }
+
+  const text = await response.text();
+  return {
+    status: response.status,
+    message: text || `Request failed with status ${response.status}`,
+    raw: text,
+  };
 };

--- a/apps/statgpt-admin-frontend/src/server/base-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/base-api.ts
@@ -1,5 +1,5 @@
 import { JWT } from 'next-auth/jwt';
-import { sendRequest, streamRequest } from './api';
+import { ApiResult, sendRequest, sendRequestSafe, streamRequest } from './api';
 
 export interface BaseApiConfig {
   host?: string;
@@ -42,6 +42,40 @@ export class BaseApi {
     return this.sendRequest<T, R>(url, 'POST', dto, qs, initHeaders, token);
   }
 
+  protected async deleteSafe<T extends object, R>(
+    url: string,
+    token?: JWT | null,
+  ): Promise<ApiResult<R>> {
+    return this.sendRequestSafe<T, R>(
+      url,
+      'DELETE',
+      void 0,
+      void 0,
+      void 0,
+      token,
+    );
+  }
+
+  protected async putSafe<T extends object, R>(
+    url: string,
+    dto: T,
+    qs?: Record<string, string>,
+    initHeaders?: HeadersInit,
+    token?: JWT | null,
+  ): Promise<ApiResult<R>> {
+    return this.sendRequestSafe<T, R>(url, 'PUT', dto, qs, initHeaders, token);
+  }
+
+  protected async postSafe<T extends object, R>(
+    url: string,
+    dto: T,
+    qs?: Record<string, string>,
+    initHeaders?: HeadersInit,
+    token?: JWT | null,
+  ): Promise<ApiResult<R>> {
+    return this.sendRequestSafe<T, R>(url, 'POST', dto, qs, initHeaders, token);
+  }
+
   protected streamRequest(url: string, token?: JWT | null) {
     return streamRequest(`${this.config.host}${url}`, 'GET', token);
   }
@@ -76,6 +110,29 @@ export class BaseApi {
       : {};
 
     return sendRequest(
+      `${tempUrl ? this.config.dialTemp : this.config.host || this.config.dial}${url}`,
+      type,
+      dto,
+      qs,
+      { ...initHeaders, ...apiKey } as HeadersInit,
+      token,
+    );
+  }
+
+  private sendRequestSafe<T extends object, R>(
+    url: string,
+    type: string,
+    dto?: T,
+    qs?: Record<string, string>,
+    initHeaders?: HeadersInit,
+    token?: JWT | null,
+    tempUrl = false,
+  ): Promise<ApiResult<R>> {
+    const apiKey = this.config.dialKey
+      ? { 'Api-key': this.config.dialKey }
+      : {};
+
+    return sendRequestSafe(
       `${tempUrl ? this.config.dialTemp : this.config.host || this.config.dial}${url}`,
       type,
       dto,

--- a/apps/statgpt-admin-frontend/src/server/data-sets-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/data-sets-api.ts
@@ -2,7 +2,7 @@ import { JWT } from 'next-auth/jwt';
 
 import { DataSet } from '@/src/models/data-sets';
 import { RequestData } from '@/src/models/request-data';
-import { MAIN_API } from './api';
+import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
 
 export const DATA_SETS_URL = `${MAIN_API}/datasets`;
@@ -23,6 +23,13 @@ export class DataSetsApi extends BaseApi {
     token: JWT | null,
   ): Promise<RequestData<DataSet> | null> {
     return this.post(DATA_SETS_URL, ds, void 0, void 0, token);
+  }
+
+  createDataSetSafe(
+    ds: DataSet,
+    token: JWT | null,
+  ): Promise<ApiResult<RequestData<DataSet>>> {
+    return this.postSafe(DATA_SETS_URL, ds, void 0, void 0, token);
   }
 
   removeDataSet(id: string, token: JWT | null): Promise<unknown> {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-admin-frontend/issues/107
- https://github.com/epam/statgpt-admin-frontend/issues/109

### Description of changes

This PR fixes dataset creation failures caused by backend validation changes and improves visibility of create errors in the UI.

#### Main points

- **Dataset creation payload fix**
  - Updated dataset create flow to send required fields expected by backend, especially **`title`** (along with `data_source_id` and `details`).
  - This aligns frontend with backend `POST /datasets` validation requirements.

- **Error handling for dataset creation**
  - Added error-aware API request path via new **safe API utils** (`ApiResult` / `ApiError`, `sendRequestSafe`, `postSafe`, etc.) without breaking existing API methods.
  - Dataset create route now uses safe flow and returns `{ ok, res }`, so UI can show backend validation/server messages instead of silent failure.

- **User-visible error notification**
  - On dataset create failure, modal stays open and shows error notification (backend message first, fallback generic message).
  - Notification z-index increased so alert is visible/clickable above modal overlay during creation errors.

- **Friendly validation messages**
  - Added centralized parsing/formatting for validation errors (e.g. missing required fields) for safer endpoints to produce clearer user-facing text.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
