### PR TITLE
feat: global error handling

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/[id]/route.ts
@@ -1,6 +1,7 @@
 import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
 import { auditLogsApi } from '@/src/app/api/api';
+import { apiResultToResponse } from '@/src/server/api';
 
 export async function GET(
   req: NextRequest,
@@ -9,9 +10,9 @@ export async function GET(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await auditLogsApi.getAuditLogById(params.id, token);
-
-    return Response.json(data);
+    return apiResultToResponse(
+      await auditLogsApi.getAuditLogById(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/audit-logs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { auditLogsApi } from '../../api';
 import { getToken } from 'next-auth/jwt';
+import { apiResultToResponse } from '@/src/server/api';
 import { mapSearchParamsToAuditLogRequest } from '@/src/utils/audit-logs';
 
 export const dynamic = 'force-dynamic';
@@ -11,9 +12,7 @@ export async function GET(req: NextRequest) {
 
     const { searchParams } = new URL(req.url);
     const params = mapSearchParamsToAuditLogRequest(searchParams);
-    const data = await auditLogsApi.getAuditLogs(token, params);
-
-    return Response.json(data);
+    return apiResultToResponse(await auditLogsApi.getAuditLogs(token, params));
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/reload-indicators/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/reload-indicators/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { channelsApi } from '../../../../../api';
 import { getToken } from 'next-auth/jwt';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,8 +12,9 @@ export async function POST(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await channelsApi.reloadDataSets(params.id, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await channelsApi.reloadDataSets(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest } from 'next/server';
 import { channelsApi } from '../../../../api';
 import { getToken } from 'next-auth/jwt';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
+
 interface ChannelDatasetPayload {
   dsId?: string;
   isReload?: boolean;
@@ -15,8 +17,9 @@ export async function GET(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await channelsApi.getChannelDataset(params.id, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await channelsApi.getChannelDataset(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
@@ -30,8 +33,9 @@ export async function DELETE(
     const params = await context.params;
     const token = await getToken({ req });
     const [id, dsId] = params.id.split('__');
-    const data = await channelsApi.removeChannelDataset(id, dsId, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await channelsApi.removeChannelDataset(id, dsId, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
@@ -55,10 +59,11 @@ export async function POST(
       return Response.json({ error: 'Missing field: dsId' }, { status: 400 });
     }
 
-    const data = res.isReload
-      ? await channelsApi.reloadDataSet(params.id, res.dsId, token)
-      : await channelsApi.addChannelDataset(params.id, res.dsId, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      res.isReload
+        ? await channelsApi.reloadDataSet(params.id, res.dsId, token)
+        : await channelsApi.addChannelDataset(params.id, res.dsId, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { channelsApi } from '../../../api';
 import { getToken } from 'next-auth/jwt';
 import { Channel } from '@/src/models/channel';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,8 +13,9 @@ export async function DELETE(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await channelsApi.removeChannel(params.id, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await channelsApi.removeChannel(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
@@ -28,8 +30,7 @@ export async function POST(req: NextRequest) {
       return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
     }
     const token = await getToken({ req });
-    const data = await channelsApi.updateChannel(res, token);
-    return Response.json(data);
+    return apiResultToResponse(await channelsApi.updateChannel(res, token));
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/import/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/import/route.ts
@@ -1,6 +1,7 @@
 import { getToken } from 'next-auth/jwt';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { channelsApi } from '@/src/app/api/api';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const runtime = 'nodejs';
 
@@ -12,15 +13,15 @@ export async function POST(req: NextRequest) {
     const updateDataSources = search.get('updateDataSources') === 'true';
     const cleanUp = search.get('cleanUp') === 'true';
     const token = await getToken({ req });
-    const res = await channelsApi.importChannel(
-      formData,
-      updateDatasets,
-      updateDataSources,
-      cleanUp,
-      token,
+    return apiResultToResponse(
+      await channelsApi.importChannel(
+        formData,
+        updateDatasets,
+        updateDataSources,
+        cleanUp,
+        token,
+      ),
     );
-
-    return NextResponse.json(res);
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/data-sources/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/data-sources/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { dataSourcesApi } from '../../../api';
 import { getToken } from 'next-auth/jwt';
 import { DataSource } from '@/src/models/data-source';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,8 +13,9 @@ export async function DELETE(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await dataSourcesApi.removeDataSource(params.id, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await dataSourcesApi.removeDataSource(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
@@ -28,8 +30,9 @@ export async function POST(req: NextRequest) {
     } catch {
       return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
     }
-    const data = await dataSourcesApi.updateDataSources(res, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await dataSourcesApi.updateDataSources(res, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/reload-dimensions/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/reload-dimensions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { dataSetsApi } from '../../../../api';
 import { getToken } from 'next-auth/jwt';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,8 +12,9 @@ export async function POST(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await dataSetsApi.reloadDimensionsDataSet(params.id, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await dataSetsApi.reloadDimensionsDataSet(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { dataSetsApi } from '../../../api';
 import { getToken } from 'next-auth/jwt';
 import { DataSet } from '@/src/models/data-sets';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,8 +13,9 @@ export async function DELETE(
   try {
     const params = await context.params;
     const token = await getToken({ req });
-    const data = await dataSetsApi.removeDataSet(params.id, token);
-    return Response.json(data);
+    return apiResultToResponse(
+      await dataSetsApi.removeDataSet(params.id, token),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
@@ -28,8 +30,7 @@ export async function POST(req: NextRequest) {
     } catch {
       return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
     }
-    const data = await dataSetsApi.updateDataSet(res, token);
-    return Response.json(data);
+    return apiResultToResponse(await dataSetsApi.updateDataSet(res, token));
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/datasets/route.ts
@@ -2,14 +2,14 @@ import { NextRequest } from 'next/server';
 import { dataSetsApi } from '../../api';
 import { getToken } from 'next-auth/jwt';
 import { DataSet } from '@/src/models/data-sets';
+import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
     const token = await getToken({ req });
-    const data = await dataSetsApi.getDataSets(token);
-    return Response.json(data);
+    return apiResultToResponse(await dataSetsApi.getDataSets(token));
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
@@ -19,22 +19,8 @@ export async function POST(req: NextRequest) {
   try {
     const payload = (await req.json()) as DataSet;
     const token = await getToken({ req });
-    const result = await dataSetsApi.createDataSetSafe(payload, token);
-
-    if (!result.ok) {
-      return Response.json({
-        ok: false,
-        res:
-          result.error.message ||
-          'Failed to create dataset. Please check required fields.',
-      });
-    }
-
-    return Response.json({ ok: true, res: result.data });
+    return apiResultToResponse(await dataSetsApi.createDataSet(payload, token));
   } catch {
-    return Response.json({
-      ok: false,
-      res: 'Internal Server Error',
-    });
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/download/import/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/download/import/route.ts
@@ -1,5 +1,6 @@
 import { documentsApi } from '@/src/app/api/api';
-import { NextRequest, NextResponse } from 'next/server';
+import { apiResultToResponse } from '@/src/server/api';
+import { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
 
@@ -9,8 +10,9 @@ export async function POST(req: NextRequest) {
     const search = req.nextUrl.searchParams;
     const targetPath = search.get('targetPath') as string;
 
-    const res = await documentsApi.uploadFile(formData, targetPath);
-    return NextResponse.json(res);
+    return apiResultToResponse(
+      await documentsApi.uploadFile(formData, targetPath),
+    );
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/audit-logs/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/audit-logs/page.tsx
@@ -5,6 +5,7 @@ import { getIsInvalidSession, getUserToken } from '@/src/utils/auth/get-token';
 import { getIsEnableAuthToggle } from '@/src/utils/get-auth-toggle';
 import { AuditLogsListView } from '@/src/components/AuditLogs/AuditLogsListView';
 import { auditLogsApi } from '../api/api';
+import { logger } from '@/src/server/logger';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +18,18 @@ export default async function Page() {
     return redirect(SIGN_IN_LINK);
   }
 
-  const enums = await auditLogsApi.getEnumValues(token);
+  const enumsResult = await auditLogsApi.getEnumValues(token);
+  if (!enumsResult.ok) {
+    logger.error(
+      `Getting audit log enum values error ${enumsResult.error.message}`,
+    );
+  }
+  const enums = enumsResult.ok ? enumsResult.data : null;
 
-  return <AuditLogsListView enums={enums} />;
+  return (
+    <AuditLogsListView
+      enums={enums}
+      initialError={enumsResult.ok ? null : enumsResult.error.message}
+    />
+  );
 }

--- a/apps/statgpt-admin-frontend/src/app/channels/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/page.tsx
@@ -25,11 +25,9 @@ export default async function Page() {
 
   let data = { data: [] as Channel[] } as RequestData<Channel> | null;
 
-  try {
-    data = await channelsApi.getChannels(token);
-  } catch (e) {
-    logger.error(`Getting channels error ${e}`);
-  }
+  const result = await channelsApi.getChannels(token);
+  if (result.ok) data = result.data;
+  else logger.error(`Getting channels error ${result.error.message}`);
 
   return (
     <ListView
@@ -37,6 +35,7 @@ export default async function Page() {
       colDefs={CHANNELS_COLUMNS}
       data={data?.data || []}
       emptyDataTitle="No Channels"
+      initialError={result.ok ? null : result.error.message}
     />
   );
 }

--- a/apps/statgpt-admin-frontend/src/app/data-sets/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/data-sets/page.tsx
@@ -24,11 +24,9 @@ export default async function Page() {
   }
   let data = { data: [] as DataSet[] } as RequestData<DataSet> | null;
 
-  try {
-    data = await dataSetsApi.getDataSets(token);
-  } catch (e) {
-    logger.error(`Getting data sets error ${e}`);
-  }
+  const result = await dataSetsApi.getDataSets(token);
+  if (result.ok) data = result.data;
+  else logger.error(`Getting data sets error ${result.error.message}`);
 
   return (
     <ListView
@@ -36,6 +34,7 @@ export default async function Page() {
       colDefs={DATA_SETS_COLUMNS_WITH_ACTIONS}
       data={data?.data || []}
       emptyDataTitle="No Datasets"
+      initialError={result.ok ? null : result.error.message}
     />
   );
 }

--- a/apps/statgpt-admin-frontend/src/app/data-sources/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/data-sources/page.tsx
@@ -25,11 +25,9 @@ export default async function Page() {
 
   let data = { data: [] as DataSource[] } as RequestData<DataSource> | null;
 
-  try {
-    data = await dataSourcesApi.getDataSources(token);
-  } catch (e) {
-    logger.error(`Getting data sources error ${e}`);
-  }
+  const result = await dataSourcesApi.getDataSources(token);
+  if (result.ok) data = result.data;
+  else logger.error(`Getting data sources error ${result.error.message}`);
 
   return (
     <ListView
@@ -37,6 +35,7 @@ export default async function Page() {
       colDefs={DATA_SOURCE_COLUMNS_WITH_ACTIONS}
       data={data?.data || []}
       emptyDataTitle="No Data Sources"
+      initialError={result.ok ? null : result.error.message}
     />
   );
 }

--- a/apps/statgpt-admin-frontend/src/app/documents/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/documents/page.tsx
@@ -25,11 +25,9 @@ export default async function Page() {
 
   let data = { data: [] as Document[] } as RequestData<Document> | null;
 
-  try {
-    data = await documentsApi.getList(null);
-  } catch (e) {
-    logger.error(`Getting documents error ${e}`);
-  }
+  const result = await documentsApi.getList(null);
+  if (result.ok) data = result.data;
+  else logger.error(`Getting documents error ${result.error.message}`);
 
   return (
     <ListView
@@ -37,6 +35,7 @@ export default async function Page() {
       colDefs={DOCUMENTS_COLUMNS_WITH_ACTIONS}
       data={(data?.results as any[]) || []}
       emptyDataTitle="No Documents"
+      initialError={result.ok ? null : result.error.message}
     />
   );
 }

--- a/apps/statgpt-admin-frontend/src/components/AddChannelsModal/AddChannelsModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddChannelsModal/AddChannelsModal.tsx
@@ -1,11 +1,8 @@
 import { useRouter } from 'next/navigation';
 import { FC, useEffect, useState } from 'react';
-import { parse } from 'yaml';
-
-import { useNotification } from '@/src/context/NotificationContext';
-import { NotificationType } from '@/src/models/notification';
 
 import { createChannel } from '@/src/app/channels/actions';
+import { useYamlParser } from '@/src/hooks/use-yaml-parser';
 import { Configuration } from '@/src/components/Configuration/Configuration';
 import { Modal } from '@/src/components/Modal/Modal';
 import { Stepper } from '@/src/components/Stepper/Stepper';
@@ -39,7 +36,7 @@ export const AddChannelsModal: FC<Props> = ({ close }) => {
 
   const [isValidChannel, setIsValidChannel] = useState(false);
   const router = useRouter();
-  const { showNotification } = useNotification();
+  const parseYaml = useYamlParser();
 
   useEffect(() => {
     setIsValidChannel(
@@ -53,19 +50,9 @@ export const AddChannelsModal: FC<Props> = ({ close }) => {
   const create = () => {
     let details = channel.details;
     if (rawConfig) {
-      try {
-        details = parse(rawConfig);
-      } catch (e) {
-        showNotification({
-          type: NotificationType.error,
-          title: 'Invalid Configuration',
-          description:
-            e instanceof Error
-              ? e.message
-              : 'YAML syntax error in configuration.',
-        });
-        return;
-      }
+      const parsed = parseYaml(rawConfig);
+      if (!parsed.ok) return;
+      details = parsed.value;
     }
     createChannel({ ...channel, details }).then(() => {
       router.refresh();

--- a/apps/statgpt-admin-frontend/src/components/AddChannelsModal/AddChannelsModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddChannelsModal/AddChannelsModal.tsx
@@ -2,6 +2,9 @@ import { useRouter } from 'next/navigation';
 import { FC, useEffect, useState } from 'react';
 import { parse } from 'yaml';
 
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
+
 import { createChannel } from '@/src/app/channels/actions';
 import { Configuration } from '@/src/components/Configuration/Configuration';
 import { Modal } from '@/src/components/Modal/Modal';
@@ -32,9 +35,11 @@ export const AddChannelsModal: FC<Props> = ({ close }) => {
     llm_model: '',
     details: {},
   });
+  const [rawConfig, setRawConfig] = useState('');
 
   const [isValidChannel, setIsValidChannel] = useState(false);
   const router = useRouter();
+  const { showNotification } = useNotification();
 
   useEffect(() => {
     setIsValidChannel(
@@ -46,7 +51,23 @@ export const AddChannelsModal: FC<Props> = ({ close }) => {
   }, [channel]);
 
   const create = () => {
-    createChannel(channel).then(() => {
+    let details = channel.details;
+    if (rawConfig) {
+      try {
+        details = parse(rawConfig);
+      } catch (e) {
+        showNotification({
+          type: NotificationType.error,
+          title: 'Invalid Configuration',
+          description:
+            e instanceof Error
+              ? e.message
+              : 'YAML syntax error in configuration.',
+        });
+        return;
+      }
+    }
+    createChannel({ ...channel, details }).then(() => {
       router.refresh();
       close();
     });
@@ -66,12 +87,7 @@ export const AddChannelsModal: FC<Props> = ({ close }) => {
       return (
         <Configuration
           height="270px"
-          onChangeConfig={(v) =>
-            setChannel({
-              ...channel,
-              details: parse(v || ''),
-            } as Channel)
-          }
+          onChangeConfig={(v) => setRawConfig(v || '')}
         />
       );
     }

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
@@ -12,6 +12,8 @@ import { DataSet } from '@/src/models/data-sets';
 import { DataSource } from '@/src/models/data-source';
 import { sendPostRequest } from '@/src/server/api';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
 import { Step } from '@/src/models/step';
 import { ModalsButtons } from './Buttons/ModalsButtons';
 import { DataSetStep } from './DataSetStep/DataSetStep';
@@ -24,6 +26,7 @@ interface Props {
 export const AddDataSetModal: FC<Props> = ({ close }) => {
   const router = useRouter();
   const withNotification = useApiNotification();
+  const { showNotification } = useNotification();
   const dataSetSteps: Step[] = [
     {
       key: DatasetStep.DataSource,
@@ -39,6 +42,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
   const [newDataSet, setDataSet] = useState<DataSet>({
     details: void 0,
   });
+  const [rawConfig, setRawConfig] = useState('');
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
   const [isLoadingData, setIsLoadingDs] = useState(false);
 
@@ -57,9 +61,25 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
   }, [dataSources, isLoadingData]);
 
   const createDataset = () => {
+    let details = newDataSet.details;
+    if (rawConfig) {
+      try {
+        details = parse(rawConfig);
+      } catch (e) {
+        showNotification({
+          type: NotificationType.error,
+          title: 'Invalid Configuration',
+          description:
+            e instanceof Error
+              ? e.message
+              : 'YAML syntax error in configuration.',
+        });
+        return;
+      }
+    }
     setIsLoadingDs(true);
     withNotification(
-      sendPostRequest('/api/v1/datasets', newDataSet),
+      sendPostRequest('/api/v1/datasets', { ...newDataSet, details }),
       'Dataset Creation Failed',
     ).then((result) => {
       setIsLoadingDs(false);
@@ -96,13 +116,10 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       return (
         <DataSetStep
           selectedDataSourceId={newDataSet?.data_source_id}
-          changeDataSet={({ title, details }) =>
-            setDataSet({
-              ...(newDataSet || {}),
-              title,
-              details,
-            } as DataSet)
-          }
+          changeDataSet={({ title, details }) => {
+            setDataSet({ ...(newDataSet || {}), title, details } as DataSet);
+            setRawConfig(details ? stringify(details) : '');
+          }}
         />
       );
     }
@@ -111,13 +128,8 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       return (
         <Configuration
           height="633px"
-          value={stringify(newDataSet.details)}
-          onChangeConfig={(v) =>
-            setDataSet({
-              ...(newDataSet || {}),
-              details: parse(v || ''),
-            } as DataSet)
-          }
+          value={rawConfig}
+          onChangeConfig={(v) => setRawConfig(v || '')}
         />
       );
     }

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
@@ -8,12 +8,10 @@ import { Configuration } from '@/src/components/Configuration/Configuration';
 import { Modal } from '@/src/components/Modal/Modal';
 import { Stepper } from '@/src/components/Stepper/Stepper';
 import { BaseStep, DatasetStep } from '@/src/constants/steps';
-import { useNotification } from '@/src/context/NotificationContext';
 import { DataSet } from '@/src/models/data-sets';
-import { NotificationType } from '@/src/models/notification';
 import { DataSource } from '@/src/models/data-source';
-import { RequestData } from '@/src/models/request-data';
 import { sendPostRequest } from '@/src/server/api';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { Step } from '@/src/models/step';
 import { ModalsButtons } from './Buttons/ModalsButtons';
 import { DataSetStep } from './DataSetStep/DataSetStep';
@@ -25,7 +23,7 @@ interface Props {
 
 export const AddDataSetModal: FC<Props> = ({ close }) => {
   const router = useRouter();
-  const { showNotification } = useNotification();
+  const withNotification = useApiNotification();
   const dataSetSteps: Step[] = [
     {
       key: DatasetStep.DataSource,
@@ -49,36 +47,26 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
   useEffect(() => {
     if (dataSources.length === 0 && !isLoadingData) {
       setIsLoadingDs(true);
-      getDataSources().then((data) => {
-        setIsLoadingDs(false);
-        setDataSources((data as RequestData<DataSource>).data);
-      });
+      withNotification(getDataSources(), 'Failed to Load Data Sources').then(
+        (result) => {
+          setIsLoadingDs(false);
+          if (result.ok) setDataSources(result.data.data);
+        },
+      );
     }
   }, [dataSources, isLoadingData]);
 
   const createDataset = () => {
     setIsLoadingDs(true);
-    sendPostRequest<DataSet, { ok: boolean; res: DataSet | string }>(
-      '/api/v1/datasets',
-      newDataSet,
-    ).then((res) => {
+    withNotification(
+      sendPostRequest('/api/v1/datasets', newDataSet),
+      'Dataset Creation Failed',
+    ).then((result) => {
       setIsLoadingDs(false);
-      if (res?.ok) {
+      if (result.ok) {
         router.refresh();
         close();
-        return;
       }
-
-      const message =
-        typeof res?.res === 'string'
-          ? res.res
-          : 'Failed to create dataset. Please check required fields.';
-
-      showNotification({
-        type: NotificationType.error,
-        title: 'Dataset Creation Failed',
-        description: message,
-      });
     });
   };
 

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/navigation';
 import { FC, useEffect, useState } from 'react';
-import { parse, stringify } from 'yaml';
+import { stringify } from 'yaml';
 
 import { getDataSources } from '@/src/app/data-sources/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
@@ -12,8 +12,7 @@ import { DataSet } from '@/src/models/data-sets';
 import { DataSource } from '@/src/models/data-source';
 import { sendPostRequest } from '@/src/server/api';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
-import { useNotification } from '@/src/context/NotificationContext';
-import { NotificationType } from '@/src/models/notification';
+import { useYamlParser } from '@/src/hooks/use-yaml-parser';
 import { Step } from '@/src/models/step';
 import { ModalsButtons } from './Buttons/ModalsButtons';
 import { DataSetStep } from './DataSetStep/DataSetStep';
@@ -26,7 +25,7 @@ interface Props {
 export const AddDataSetModal: FC<Props> = ({ close }) => {
   const router = useRouter();
   const withNotification = useApiNotification();
-  const { showNotification } = useNotification();
+  const parseYaml = useYamlParser();
   const dataSetSteps: Step[] = [
     {
       key: DatasetStep.DataSource,
@@ -63,19 +62,9 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
   const createDataset = () => {
     let details = newDataSet.details;
     if (rawConfig) {
-      try {
-        details = parse(rawConfig);
-      } catch (e) {
-        showNotification({
-          type: NotificationType.error,
-          title: 'Invalid Configuration',
-          description:
-            e instanceof Error
-              ? e.message
-              : 'YAML syntax error in configuration.',
-        });
-        return;
-      }
+      const parsed = parseYaml(rawConfig);
+      if (!parsed.ok) return;
+      details = parsed.value;
     }
     setIsLoadingDs(true);
     withNotification(

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
@@ -5,8 +5,8 @@ import { loadAvailableDataSets } from '@/src/app/data-sources/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { BASE_COLUMNS } from '@/src/constants/columns/common-columns';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { DataSet } from '@/src/models/data-sets';
-import { RequestData } from '@/src/models/request-data';
 
 interface Props {
   selectedDataSourceId?: number;
@@ -17,6 +17,7 @@ export const DataSetStep: FC<Props> = ({
   selectedDataSourceId,
   changeDataSet,
 }) => {
+  const withNotification = useApiNotification();
   const [dataSets, setDataSets] = useState<DataSet[]>([]);
   const [isLoadingDs, setIsLoadingDs] = useState(false);
 
@@ -34,9 +35,12 @@ export const DataSetStep: FC<Props> = ({
     if (dataSets.length === 0 && !isLoadingDs && selectedDataSourceId != null) {
       setIsLoadingDs(true);
 
-      loadAvailableDataSets(selectedDataSourceId).then((data) => {
+      withNotification(
+        loadAvailableDataSets(selectedDataSourceId),
+        'Failed to Load Datasets',
+      ).then((result) => {
         setIsLoadingDs(false);
-        setDataSets((data as RequestData<DataSet>).data);
+        if (result.ok) setDataSets(result.data.data);
       });
     }
   }, [dataSets, selectedDataSourceId, isLoadingDs]);

--- a/apps/statgpt-admin-frontend/src/components/AddDataSourceModal/AddDataSourceModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSourceModal/AddDataSourceModal.tsx
@@ -12,6 +12,8 @@ import { Modal } from '@/src/components/Modal/Modal';
 import { Stepper } from '@/src/components/Stepper/Stepper';
 import { BaseStep } from '@/src/constants/steps';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
 import { DataSource, DataSourceType } from '@/src/models/data-source';
 import { Step } from '@/src/models/step';
 import { ModalButtons } from './Buttons/ModalButtons';
@@ -36,11 +38,13 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
   const [dataSource, setDataSource] = useState<DataSource>({
     details: {},
   });
+  const [rawConfig, setRawConfig] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [dsTypes, setDsTypes] = useState<DataSourceType[]>([]);
   const [isValidDataSource, setIsValidDataSource] = useState(false);
   const router = useRouter();
   const withNotification = useApiNotification();
+  const { showNotification } = useNotification();
 
   useEffect(() => {
     setIsValidDataSource(dataSource?.title != null && dataSource?.title !== '');
@@ -61,8 +65,24 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
   }, []);
 
   const create = () => {
+    let details = dataSource.details;
+    if (rawConfig) {
+      try {
+        details = parse(rawConfig);
+      } catch (e) {
+        showNotification({
+          type: NotificationType.error,
+          title: 'Invalid Configuration',
+          description:
+            e instanceof Error
+              ? e.message
+              : 'YAML syntax error in configuration.',
+        });
+        return;
+      }
+    }
     withNotification(
-      createDataSource(dataSource),
+      createDataSource({ ...dataSource, details }),
       'Create Data Source Failed',
     ).then((result) => {
       if (result.ok) {
@@ -102,12 +122,7 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
       return (
         <Configuration
           height="360px"
-          onChangeConfig={(v) =>
-            setDataSource({
-              ...(dataSource || {}),
-              details: parse(v || ''),
-            } as DataSource)
-          }
+          onChangeConfig={(v) => setRawConfig(v || '')}
         />
       );
     }

--- a/apps/statgpt-admin-frontend/src/components/AddDataSourceModal/AddDataSourceModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSourceModal/AddDataSourceModal.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/navigation';
 import { FC, useEffect, useState } from 'react';
-import { parse } from 'yaml';
 
 import {
   createDataSource,
@@ -12,8 +11,7 @@ import { Modal } from '@/src/components/Modal/Modal';
 import { Stepper } from '@/src/components/Stepper/Stepper';
 import { BaseStep } from '@/src/constants/steps';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
-import { useNotification } from '@/src/context/NotificationContext';
-import { NotificationType } from '@/src/models/notification';
+import { useYamlParser } from '@/src/hooks/use-yaml-parser';
 import { DataSource, DataSourceType } from '@/src/models/data-source';
 import { Step } from '@/src/models/step';
 import { ModalButtons } from './Buttons/ModalButtons';
@@ -44,7 +42,7 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
   const [isValidDataSource, setIsValidDataSource] = useState(false);
   const router = useRouter();
   const withNotification = useApiNotification();
-  const { showNotification } = useNotification();
+  const parseYaml = useYamlParser();
 
   useEffect(() => {
     setIsValidDataSource(dataSource?.title != null && dataSource?.title !== '');
@@ -67,19 +65,9 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
   const create = () => {
     let details = dataSource.details;
     if (rawConfig) {
-      try {
-        details = parse(rawConfig);
-      } catch (e) {
-        showNotification({
-          type: NotificationType.error,
-          title: 'Invalid Configuration',
-          description:
-            e instanceof Error
-              ? e.message
-              : 'YAML syntax error in configuration.',
-        });
-        return;
-      }
+      const parsed = parseYaml(rawConfig);
+      if (!parsed.ok) return;
+      details = parsed.value;
     }
     withNotification(
       createDataSource({ ...dataSource, details }),

--- a/apps/statgpt-admin-frontend/src/components/AddDataSourceModal/AddDataSourceModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSourceModal/AddDataSourceModal.tsx
@@ -11,6 +11,7 @@ import { Configuration } from '@/src/components/Configuration/Configuration';
 import { Modal } from '@/src/components/Modal/Modal';
 import { Stepper } from '@/src/components/Stepper/Stepper';
 import { BaseStep } from '@/src/constants/steps';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { DataSource, DataSourceType } from '@/src/models/data-source';
 import { Step } from '@/src/models/step';
 import { ModalButtons } from './Buttons/ModalButtons';
@@ -39,6 +40,7 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
   const [dsTypes, setDsTypes] = useState<DataSourceType[]>([]);
   const [isValidDataSource, setIsValidDataSource] = useState(false);
   const router = useRouter();
+  const withNotification = useApiNotification();
 
   useEffect(() => {
     setIsValidDataSource(dataSource?.title != null && dataSource?.title !== '');
@@ -48,17 +50,25 @@ export const AddDataSourceModal: FC<Props> = ({ close }) => {
     if (dsTypes.length === 0 && !isLoading) {
       setIsLoading(true);
 
-      getDataSourcesTypes().then((types) => {
+      withNotification(
+        getDataSourcesTypes(),
+        'Failed to Load Data Source Types',
+      ).then((result) => {
         setIsLoading(false);
-        setDsTypes(types?.data || []);
+        if (result.ok) setDsTypes(result.data.data);
       });
     }
   }, []);
 
   const create = () => {
-    createDataSource(dataSource).then(() => {
-      router.refresh();
-      close();
+    withNotification(
+      createDataSource(dataSource),
+      'Create Data Source Failed',
+    ).then((result) => {
+      if (result.ok) {
+        router.refresh();
+        close();
+      }
     });
   };
 

--- a/apps/statgpt-admin-frontend/src/components/AddDocument/AddDocument.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDocument/AddDocument.tsx
@@ -14,6 +14,7 @@ import { BaseStep } from '@/src/constants/steps';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/src/constants/layout';
 import { sendPostRequest } from '../../server/api';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 
 interface Props {
   close: () => void;
@@ -41,29 +42,36 @@ export const AddDocumentModal: FC<Props> = ({ close }) => {
 
   const [activeStep, setActiveStep] = useState(steps[0].key);
   const router = useRouter();
+  const withNotification = useApiNotification();
 
   useEffect(() => {
-    getMetaData().then((meta) => {
-      setConfiguration(meta);
-    });
+    withNotification(getMetaData(), 'Failed to Load Metadata').then(
+      (result) => {
+        if (result.ok) setConfiguration(result.data);
+      },
+    );
   }, []);
 
   const handleFileInput = (files?: FileList): void => {
     setFiles(files);
   };
 
-  const addDocument = (): void => {
+  const addDocument = async (): Promise<void> => {
     if (files) {
       const formData = new FormData();
       formData.append('attachment', files[0], files[0].name);
       formData.append('metadata', metadata);
-      sendPostRequest(
-        `/api/v1/download/import?targetPath=${targetPath}`,
-        formData,
-      ).then(() => {
+      const result = await withNotification(
+        sendPostRequest(
+          `/api/v1/download/import?targetPath=${targetPath}`,
+          formData,
+        ),
+        'Upload Failed',
+      );
+      if (result.ok) {
         router.refresh();
         close();
-      });
+      }
     }
   };
 

--- a/apps/statgpt-admin-frontend/src/components/AuditLogs/AuditLogDetails/AuditLogDetailsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AuditLogs/AuditLogDetails/AuditLogDetailsView.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState, useTransition } from 'react';
 import { sendGetRequest } from '@/src/server/api';
 import { DataField } from './DataField';
 import { CopyButton } from '../../BaseComponents/CopyButton/CopyButton';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 
 export const AuditLogDetailsView = ({
   data,
@@ -18,6 +19,7 @@ export const AuditLogDetailsView = ({
   const [details, setDetails] = useState<AuditLogDetails | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const withNotification = useApiNotification();
 
   useEffect(() => {
     let cancelled = false;
@@ -27,8 +29,9 @@ export const AuditLogDetailsView = ({
 
     startTransition(() => {
       (async () => {
-        const result = await sendGetRequest<AuditLogDetails>(
-          `/api/v1/audit-logs/${data.id}`,
+        const result = await withNotification(
+          sendGetRequest<AuditLogDetails>(`/api/v1/audit-logs/${data.id}`),
+          'Failed to Load Action Details',
         );
 
         if (!result.ok) {
@@ -44,7 +47,7 @@ export const AuditLogDetailsView = ({
     return () => {
       cancelled = true;
     };
-  }, [data.id]);
+  }, [data.id, withNotification]);
 
   useEffect(() => {
     const handleEscapeKey = (event: KeyboardEvent) => {

--- a/apps/statgpt-admin-frontend/src/components/AuditLogs/AuditLogDetails/AuditLogDetailsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AuditLogs/AuditLogDetails/AuditLogDetailsView.tsx
@@ -27,20 +27,17 @@ export const AuditLogDetailsView = ({
 
     startTransition(() => {
       (async () => {
-        try {
-          const details = await sendGetRequest<any, AuditLogDetails>(
-            `/api/v1/audit-logs/${data.id}`,
-          );
+        const result = await sendGetRequest<AuditLogDetails>(
+          `/api/v1/audit-logs/${data.id}`,
+        );
 
-          if (!details) {
-            if (!cancelled) setError('Failed to load action details.');
-            return;
-          }
-
-          if (!cancelled) setDetails(details);
-        } catch {
-          if (!cancelled) setError('Failed to load action details.');
+        if (!result.ok) {
+          if (!cancelled)
+            setError(result.error.message || 'Failed to load action details.');
+          return;
         }
+
+        if (!cancelled) setDetails(result.data);
       })();
     });
 
@@ -113,9 +110,7 @@ export const AuditLogDetailsView = ({
           {(showLoader || error) && (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded">
               {error ? (
-                <span className="text-sm text-error">
-                  Failed to load action details.
-                </span>
+                <span className="text-sm text-error">{error}</span>
               ) : (
                 <div className="flex items-center gap-3 text-sm">
                   <span className="inline-block size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />

--- a/apps/statgpt-admin-frontend/src/components/AuditLogs/AuditLogsListView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AuditLogs/AuditLogsListView.tsx
@@ -17,6 +17,9 @@ import type { RequestData } from '@/src/models/request-data';
 import { sendGetRequest } from '@/src/server/api';
 import { DEFAULT_GRID_PAGE_SIZE } from '@/src/constants/columns/grid';
 import { useAuditLogFiltersInUrl } from '@/src/hooks/use-audit-logs-filters-in-url';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
 import { mapAuditLogRequestToQueryString } from '@/src/utils/audit-logs';
 import { getEnumFilterValue, getTextContains } from '@/src/utils/client/grid';
 import { ListContent } from '../ListView/ListContent/ListContent';
@@ -24,13 +27,30 @@ import { getAuditLogsColumns } from '@/src/constants/columns/audit-logs';
 
 interface AuditLogsListViewProps {
   enums?: AuditLogEnumValues | null;
+  initialError?: string | null;
 }
 
-export function AuditLogsListView({ enums }: AuditLogsListViewProps) {
+export function AuditLogsListView({
+  enums,
+  initialError,
+}: AuditLogsListViewProps) {
   const [totalCount, setTotalCount] = useState<number | undefined>(undefined);
 
   const { filters, queryKey } = useAuditLogFiltersInUrl();
+  const withNotification = useApiNotification();
+  const { showNotification } = useNotification();
   const [refreshToken, setRefreshToken] = useState(0);
+
+  useEffect(() => {
+    if (initialError) {
+      showNotification({
+        type: NotificationType.error,
+        title: 'Failed to load data',
+        description: initialError,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const filtersRef = useRef(filters);
   useEffect(() => {
@@ -68,15 +88,19 @@ export function AuditLogsListView({ enums }: AuditLogsListViewProps) {
 
       const query = mapAuditLogRequestToQueryString(request);
 
-      const payload = await sendGetRequest<any, RequestData<AuditLogDetails>>(
-        `/api/v1/audit-logs?${query}`,
+      const result = await withNotification(
+        sendGetRequest<RequestData<AuditLogDetails>>(
+          `/api/v1/audit-logs?${query}`,
+        ),
+        'Failed to Load Audit Logs',
       );
 
-      if (!payload || !payload.data) {
+      if (!result.ok || !result.data.data) {
         setTotalCount(0);
         return { rows: [], total: 0 };
       }
 
+      const payload = result.data;
       const rows = payload.data ?? payload.results ?? [];
       const total =
         typeof payload.total === 'number' ? payload.total : payload.count;
@@ -84,7 +108,7 @@ export function AuditLogsListView({ enums }: AuditLogsListViewProps) {
       setTotalCount(total);
       return { rows, total };
     },
-    [],
+    [withNotification],
   );
 
   const columns = useMemo(() => getAuditLogsColumns({ enums }), [enums]);

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/AddDataSets/AddDataSets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/AddDataSets/AddDataSets.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { GridView } from '@/src/components/GridView/GridView';
 import { Modal } from '@/src/components/Modal/Modal';
 import { BASE_COLUMNS } from '@/src/constants/columns/common-columns';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { DataSet } from '@/src/models/data-sets';
 import { RequestData } from '@/src/models/request-data';
 import { sendGetRequest } from '@/src/server/api';
@@ -19,6 +20,7 @@ export const AddDatasets: FC<Props> = ({ close, add }) => {
   const [dataSets, setDataSets] = useState<DataSet[]>([]);
   const [selectedDataSetIds, setSelectedDataSetIds] = useState<number[]>([]);
   const [isLoadingData, setIsLoadingDs] = useState(false);
+  const withNotification = useApiNotification();
 
   const gridOptions: GridOptions = {
     rowSelection: 'multiple',
@@ -34,9 +36,12 @@ export const AddDatasets: FC<Props> = ({ close, add }) => {
   useEffect(() => {
     if (dataSets.length === 0 && !isLoadingData) {
       setIsLoadingDs(true);
-      sendGetRequest(DATA_SETS_URL).then((data) => {
+      withNotification(
+        sendGetRequest<RequestData<DataSet>>(DATA_SETS_URL),
+        'Failed to Load Datasets',
+      ).then((result) => {
         setIsLoadingDs(false);
-        setDataSets((data as RequestData<DataSet>).data);
+        if (result.ok) setDataSets(result.data.data);
       });
     }
   }, []);

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/ChannelView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/ChannelView.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect, useState } from 'react';
 
 import { getChannel } from '@/src/app/channels/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { Channel } from '@/src/models/channel';
 import { DataSetsView } from './Datasets/Datasets';
 
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export const ChannelView: FC<Props> = ({ selectedChannelId }) => {
+  const withNotification = useApiNotification();
   const [selectedChannel, setSelectedChannel] = useState<Channel | undefined>(
     void 0,
   );
@@ -20,9 +22,12 @@ export const ChannelView: FC<Props> = ({ selectedChannelId }) => {
 
   useEffect(() => {
     if (selectedChannel == null) {
-      getChannel(selectedChannelId).then((data) => {
+      withNotification(
+        getChannel(selectedChannelId),
+        'Failed to Load Channel',
+      ).then((result) => {
         setIsLoadingChannel(false);
-        setSelectedChannel(data as Channel);
+        if (result.ok) setSelectedChannel(result.data);
       });
     }
   }, [selectedChannelId]);

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -23,22 +23,58 @@ import {
 } from '@/src/server/channels-api';
 import { AddDatasets } from '../AddDataSets/AddDataSets';
 import { IconCopy, IconDownload, IconRefreshDot } from '@tabler/icons-react';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 
 interface Props {
   selectedChannelId?: string;
 }
 
 export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
+  const { showNotification, removeNotification } = useNotification();
+  const withNotification = useApiNotification();
+
+  const [showModal, setShowModal] = useState(false);
+  const [isLoadingChannelDataSets, setIsLoadingChannelDataSets] =
+    useState(false);
+
+  const [selectedChannelDataSets, setSelectedChannelDataSets] = useState<
+    DataSet[]
+  >([]);
+
+  const updateDataSet = useCallback(() => {
+    if (selectedChannelId != null && !isLoadingChannelDataSets) {
+      setIsLoadingChannelDataSets(true);
+      withNotification(
+        sendGetRequest<RequestData<DataSet>>(
+          CHANNEL_DATA_SETS_URL(selectedChannelId),
+        ),
+        'Failed to Load Datasets',
+      ).then((result) => {
+        setIsLoadingChannelDataSets(false);
+        if (result.ok) {
+          setSelectedChannelDataSets([...result.data.data]);
+        }
+      });
+    }
+  }, [selectedChannelId, isLoadingChannelDataSets, withNotification]);
+
   const deleteDataSet = (id?: number) => {
     setIsLoadingChannelDataSets(true);
-    sendDeleteRequest(
-      CHANNEL_DATA_SETS_URL(`${selectedChannelId as string}__${id as number}`),
-    ).then(() => {
-      updateDataSet();
+    withNotification(
+      sendDeleteRequest(
+        CHANNEL_DATA_SETS_URL(
+          `${selectedChannelId as string}__${id as number}`,
+        ),
+      ),
+      'Delete Failed',
+    ).then((result) => {
+      if (result.ok) {
+        updateDataSet();
+      } else {
+        setIsLoadingChannelDataSets(false);
+      }
     });
   };
-
-  const { showNotification, removeNotification } = useNotification();
 
   const exportEntity = () => {
     const id = showNotification({
@@ -47,15 +83,15 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
       description: 'Preparing export files',
       duration: undefined,
     });
-    exportChannel(selectedChannelId || '').then((res) => {
+    exportChannel(selectedChannelId || '').then((result) => {
       removeNotification(id);
-      if ((res as { ok: boolean }).ok) {
-        window.open(`/${(res as { res: string }).res}`, '_blank');
+      if (result.ok) {
+        window.open(`/${result.data}`, '_blank');
       } else {
         showNotification({
           type: NotificationType.error,
           title: 'Export Failed',
-          description: (res as { res: string }).res,
+          description: result.error.message,
         });
       }
     });
@@ -89,33 +125,20 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
     ),
   ];
 
-  const [showModal, setShowModal] = useState(false);
-  const [isLoadingChannelDataSets, setIsLoadingChannelDataSets] =
-    useState(false);
-
-  const [selectedChannelDataSets, setSelectedChannelDataSets] = useState<
-    DataSet[]
-  >([]);
-
-  const updateDataSet = useCallback(() => {
-    if (selectedChannelId != null && !isLoadingChannelDataSets) {
-      setIsLoadingChannelDataSets(true);
-      sendGetRequest(CHANNEL_DATA_SETS_URL(selectedChannelId)).then((data) => {
-        setIsLoadingChannelDataSets(false);
-        setSelectedChannelDataSets([...(data as RequestData<DataSet>).data]);
-      });
-    }
-  }, []);
-
   const deduplicate = useCallback(() => {
-    deduplicateDataset(selectedChannelId as string).then(() => {
-      showNotification({
-        type: NotificationType.success,
-        title: 'Deduplication in progress',
-        description: 'The deduplication runs in the background',
-      });
+    withNotification(
+      deduplicateDataset(selectedChannelId as string),
+      'Deduplication Failed',
+    ).then((result) => {
+      if (result.ok) {
+        showNotification({
+          type: NotificationType.success,
+          title: 'Deduplication in progress',
+          description: 'The deduplication runs in the background',
+        });
+      }
     });
-  }, []);
+  }, [selectedChannelId]);
 
   useEffect(() => {
     if (selectedChannelId != null && selectedChannelDataSets.length === 0) {
@@ -124,29 +147,45 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
   }, [selectedChannelId]);
 
   const recalculateIndexes = () => {
-    sendPostRequest(
-      RELOAD_ALL_DATASETS_CHANNEL_URL(selectedChannelId as string),
-    ).then(() => {
-      updateDataSet();
+    withNotification(
+      sendPostRequest(
+        RELOAD_ALL_DATASETS_CHANNEL_URL(selectedChannelId as string),
+      ),
+      'Recalculate Failed',
+    ).then((result) => {
+      if (result.ok) {
+        updateDataSet();
+      }
     });
   };
 
-  const addDataSetsIds = useCallback((ids: number[]) => {
-    const req$ = ids.map((id) => {
-      return sendPostRequest(
-        CHANNEL_DATA_SETS_URL(selectedChannelId as string),
-        { dsId: id },
-      );
-    });
+  const addDataSetsIds = useCallback(
+    (ids: number[]) => {
+      const req$ = ids.map((id) => {
+        return sendPostRequest(
+          CHANNEL_DATA_SETS_URL(selectedChannelId as string),
+          { dsId: id },
+        );
+      });
 
-    if (req$.length === 0) {
-      return;
-    }
-    Promise.all(req$).then(() => {
-      setShowModal(false);
-      updateDataSet();
-    });
-  }, []);
+      if (req$.length === 0) {
+        return;
+      }
+      Promise.all(req$).then((results) => {
+        const firstFailed = results.find((r) => !r.ok);
+        if (firstFailed && !firstFailed.ok) {
+          showNotification({
+            type: NotificationType.error,
+            title: 'Add Dataset Failed',
+            description: firstFailed.error.message,
+          });
+        }
+        setShowModal(false);
+        updateDataSet();
+      });
+    },
+    [selectedChannelId, showNotification, updateDataSet],
+  );
 
   return (
     <div className="flex flex-col h-full">

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -1,4 +1,4 @@
-'use clients';
+'use client';
 
 import { FC, useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/apps/statgpt-admin-frontend/src/components/EditDataEntity/EditDataEntity.tsx
+++ b/apps/statgpt-admin-frontend/src/components/EditDataEntity/EditDataEntity.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/navigation';
 import { FC, useState } from 'react';
-import { parse, stringify } from 'yaml';
+import { stringify } from 'yaml';
 
 import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { MonacoEditor } from '@/src/components/Editor/Editor';
@@ -8,8 +8,7 @@ import { Modal } from '@/src/components/Modal/Modal';
 import { BaseEntityWithDetails } from '@/src/models/base-entity';
 import { sendPostRequest } from '@/src/server/api';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
-import { useNotification } from '@/src/context/NotificationContext';
-import { NotificationType } from '@/src/models/notification';
+import { useYamlParser } from '@/src/hooks/use-yaml-parser';
 
 interface Props {
   close: () => void;
@@ -21,28 +20,16 @@ export const EditDataEntity: FC<Props> = ({ close, entity, url }) => {
   const [config, setConfig] = useState<string>(stringify(entity.details));
   const router = useRouter();
   const withNotification = useApiNotification();
-  const { showNotification } = useNotification();
+  const parseYaml = useYamlParser();
 
   const updateEntity = async () => {
-    let parsedDetails: unknown;
-    try {
-      parsedDetails = parse(config);
-    } catch (e) {
-      showNotification({
-        type: NotificationType.error,
-        title: 'Invalid Configuration',
-        description:
-          e instanceof Error
-            ? e.message
-            : 'YAML syntax error in configuration.',
-      });
-      return;
-    }
+    const parsed = parseYaml(config);
+    if (!parsed.ok) return;
 
     const result = await withNotification(
       sendPostRequest(`${url}/${entity.id}`, {
         ...entity,
-        details: parsedDetails,
+        details: parsed.value,
       }),
       'Save Failed',
     );

--- a/apps/statgpt-admin-frontend/src/components/EditDataEntity/EditDataEntity.tsx
+++ b/apps/statgpt-admin-frontend/src/components/EditDataEntity/EditDataEntity.tsx
@@ -8,6 +8,8 @@ import { Modal } from '@/src/components/Modal/Modal';
 import { BaseEntityWithDetails } from '@/src/models/base-entity';
 import { sendPostRequest } from '@/src/server/api';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
 
 interface Props {
   close: () => void;
@@ -19,12 +21,28 @@ export const EditDataEntity: FC<Props> = ({ close, entity, url }) => {
   const [config, setConfig] = useState<string>(stringify(entity.details));
   const router = useRouter();
   const withNotification = useApiNotification();
+  const { showNotification } = useNotification();
 
   const updateEntity = async () => {
+    let parsedDetails: unknown;
+    try {
+      parsedDetails = parse(config);
+    } catch (e) {
+      showNotification({
+        type: NotificationType.error,
+        title: 'Invalid Configuration',
+        description:
+          e instanceof Error
+            ? e.message
+            : 'YAML syntax error in configuration.',
+      });
+      return;
+    }
+
     const result = await withNotification(
       sendPostRequest(`${url}/${entity.id}`, {
         ...entity,
-        details: parse(config),
+        details: parsedDetails,
       }),
       'Save Failed',
     );

--- a/apps/statgpt-admin-frontend/src/components/EditDataEntity/EditDataEntity.tsx
+++ b/apps/statgpt-admin-frontend/src/components/EditDataEntity/EditDataEntity.tsx
@@ -7,6 +7,7 @@ import { MonacoEditor } from '@/src/components/Editor/Editor';
 import { Modal } from '@/src/components/Modal/Modal';
 import { BaseEntityWithDetails } from '@/src/models/base-entity';
 import { sendPostRequest } from '@/src/server/api';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 
 interface Props {
   close: () => void;
@@ -17,15 +18,20 @@ interface Props {
 export const EditDataEntity: FC<Props> = ({ close, entity, url }) => {
   const [config, setConfig] = useState<string>(stringify(entity.details));
   const router = useRouter();
+  const withNotification = useApiNotification();
 
   const updateEntity = async () => {
-    await sendPostRequest(`${url}/${entity.id}`, {
-      ...entity,
-      details: parse(config),
-    }).then(() => {
+    const result = await withNotification(
+      sendPostRequest(`${url}/${entity.id}`, {
+        ...entity,
+        details: parse(config),
+      }),
+      'Save Failed',
+    );
+    if (result.ok) {
       router.refresh();
       close();
-    });
+    }
   };
 
   return (

--- a/apps/statgpt-admin-frontend/src/components/JobsView/JobsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/JobsView/JobsView.tsx
@@ -5,6 +5,7 @@ import { FC, useEffect, useState } from 'react';
 import { getChannelJobs } from '@/src/app/channels/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { Job } from '@/src/models/job';
 import { ColDef } from 'ag-grid-community';
 import { JobsActionColumn } from './ActionColumn';
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export const JobsView: FC<Props> = ({ selectedChannelId }) => {
+  const withNotification = useApiNotification();
   const [isLoading, setIsLoading] = useState(false);
   const [jobs, setJobs] = useState<Job[]>([]);
 
@@ -59,9 +61,11 @@ export const JobsView: FC<Props> = ({ selectedChannelId }) => {
 
   useEffect(() => {
     setIsLoading(true);
-    getChannelJobs(selectedChannelId).then((jobs) => {
-      setJobs(jobs || []);
-
+    withNotification(
+      getChannelJobs(selectedChannelId),
+      'Failed to Load Jobs',
+    ).then((result) => {
+      setJobs(result.ok ? result.data : []);
       setIsLoading(false);
     });
   }, [selectedChannelId]);

--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
@@ -24,6 +24,7 @@ import { RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL } from '@/src/server/data-sets-
 import { getDeleteDescription, getDeleteTitle, getUrl } from './utils';
 import { useNotification } from '@/src/context/NotificationContext';
 import { NotificationType } from '../../../models/notification';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 
 interface Props extends CustomCellRendererProps {
   items: EntityOperation[];
@@ -45,11 +46,15 @@ export const ActionColumn: FC<Props> = ({
   const [isOpenEditModal, setIsOpenEditModal] = useState(false);
   const [isOpenDeleteModal, setIsOpenDeleteModal] = useState(false);
   const { showNotification, removeNotification } = useNotification();
+  const withNotification = useApiNotification();
+
   const confirmDelete = () => {
     if (listView === Menu.DOCUMENTS) {
-      removeDocument(data.id).then(() => {
-        router.refresh();
-      });
+      withNotification(removeDocument(data.id), 'Delete Failed').then(
+        (result) => {
+          if (result.ok) router.refresh();
+        },
+      );
       return;
     }
 
@@ -59,16 +64,21 @@ export const ActionColumn: FC<Props> = ({
     }
 
     if (listView === Menu.CHANNELS) {
-      removeChannel(data.id).then(() => {
-        router.refresh();
-      });
+      withNotification(removeChannel(data.id), 'Delete Failed').then(
+        (result) => {
+          if (result.ok) router.refresh();
+        },
+      );
       return;
     }
 
-    sendDeleteRequest(
-      `${getUrl(listView)}/${data.id || data.deployment_id}`,
-    ).then(() => {
-      router.refresh();
+    withNotification(
+      sendDeleteRequest(`${getUrl(listView)}/${data.id || data.deployment_id}`),
+      'Delete Failed',
+    ).then((result) => {
+      if (result.ok) {
+        router.refresh();
+      }
     });
   };
 
@@ -80,15 +90,15 @@ export const ActionColumn: FC<Props> = ({
       duration: undefined,
     });
     if (listView === Menu.CHANNELS) {
-      exportChannel(data.id || data.deployment_id).then((res) => {
+      exportChannel(data.id || data.deployment_id).then((result) => {
         removeNotification(id);
-        if ((res as { ok: boolean }).ok) {
-          window.open((res as { res: string }).res, '_blank');
+        if (result.ok) {
+          window.open(result.data, '_blank');
         } else {
           showNotification({
             type: NotificationType.error,
             title: 'Export Failed',
-            description: (res as { res: string }).res,
+            description: result.error.message,
           });
         }
       });
@@ -97,27 +107,31 @@ export const ActionColumn: FC<Props> = ({
 
   const recalculateDataSet = () => {
     if (listView === Menu.DATA_SETS) {
-      sendPostRequest(
-        RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL(data.id),
-        {},
-      ).then(() => {
-        // add alert
-        close();
+      withNotification(
+        sendPostRequest(RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL(data.id), {}),
+        'Recalculate Failed',
+      ).then((result) => {
+        if (result.ok) {
+          close();
+        }
       });
     }
 
     if (listView === Menu.CHANNELS) {
       const channelId = pathname.split('/')[2];
-      sendPostRequest(CHANNEL_DATA_SETS_URL(channelId), {
-        dsId: data.dataset_id,
-        isReload: true,
-      }).then((ds) => {
-        const status = (ds as DataSet).preprocessing_status;
-        node.updateData({
-          ...node.data,
-          preprocessing_status: status,
-        } as unknown as BaseEntity);
-        // add alert
+      withNotification(
+        sendPostRequest<{ dsId: number; isReload: boolean }, DataSet>(
+          CHANNEL_DATA_SETS_URL(channelId),
+          { dsId: data.dataset_id, isReload: true },
+        ),
+        'Recalculate Failed',
+      ).then((result) => {
+        if (result.ok) {
+          node.updateData({
+            ...node.data,
+            preprocessing_status: result.data.preprocessing_status,
+          } as unknown as BaseEntity);
+        }
         close();
       });
     }

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
@@ -2,7 +2,7 @@
 
 import { ColDef, GridOptions } from 'ag-grid-community';
 import { useRouter } from 'next/navigation';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useEffect } from 'react';
 
 import { Menu, MenuUrl } from '@/src/constants/menu';
 import { BaseEntity } from '@/src/models/base-entity';
@@ -12,6 +12,8 @@ import {
   FetchRowsResult,
 } from '@/src/components/GridView/GridView';
 import { ListHeader } from '../ListHeader/ListHeader';
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
 
 interface Props<T = BaseEntity> {
   menuItem: Menu;
@@ -24,6 +26,7 @@ interface Props<T = BaseEntity> {
   totalCount?: number;
   queryKey?: string;
   refreshToken?: number;
+  initialError?: string | null;
 }
 
 export function ListContent<T = BaseEntity>({
@@ -37,8 +40,21 @@ export function ListContent<T = BaseEntity>({
   queryKey,
   refreshToken,
   withHeader = true,
+  initialError,
 }: Props<T>) {
   const router = useRouter();
+  const { showNotification } = useNotification();
+
+  useEffect(() => {
+    if (initialError) {
+      showNotification({
+        type: NotificationType.error,
+        title: 'Failed to load data',
+        description: initialError,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onCellClicked = useCallback(
     (event: any) => {

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ListHeader.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ListHeader.tsx
@@ -6,11 +6,10 @@ import { createPortal } from 'react-dom';
 
 import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { Menu } from '@/src/constants/menu';
-import { useNotification } from '@/src/context/NotificationContext';
-import { NotificationType } from '@/src/models/notification';
 import { AddEntityModal } from '../AddEntityModal';
 import { ImportChannelModal } from './ImportChannelModal';
 import { sendPostRequest } from '../../../server/api';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 
 interface Props {
   title: string;
@@ -22,8 +21,7 @@ export const ListHeader: FC<Props> = ({ title, count }) => {
   const [showImportModal, setShowImportModal] = useState(false);
 
   const router = useRouter();
-
-  const { showNotification } = useNotification();
+  const withNotification = useApiNotification();
 
   const uploadFile = (
     files: FileList,
@@ -35,18 +33,15 @@ export const ListHeader: FC<Props> = ({ title, count }) => {
     const formData = new FormData();
     formData.append('file', files[0], files[0].name);
 
-    sendPostRequest(
-      `/api/v1/channels/import?updateDatasets=${updateDatasets}&updateDataSources=${updateDataSources}&cleanUp=${cleanUp}`,
-      formData,
-    ).then((res) => {
-      if ((res as { ok: boolean }).ok) {
+    withNotification(
+      sendPostRequest(
+        `/api/v1/channels/import?updateDatasets=${updateDatasets}&updateDataSources=${updateDataSources}&cleanUp=${cleanUp}`,
+        formData,
+      ),
+      'Import Failed',
+    ).then((result) => {
+      if (result.ok) {
         router.refresh();
-      } else {
-        showNotification({
-          type: NotificationType.error,
-          title: 'Import Failed',
-          description: (res as { res: string }).res,
-        });
       }
     });
   };

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListView.tsx
@@ -19,6 +19,7 @@ interface Props<T = BaseEntity> {
   totalCount?: number;
   queryKey?: string;
   refreshToken?: number;
+  initialError?: string | null;
 }
 
 export function ListView<T = BaseEntity>({
@@ -32,6 +33,7 @@ export function ListView<T = BaseEntity>({
   totalCount,
   queryKey,
   refreshToken,
+  initialError,
 }: Props<T>) {
   return (
     <div className="flex flex-col h-full rounded bg-layer-2 common-paddings">
@@ -46,6 +48,7 @@ export function ListView<T = BaseEntity>({
         withHeader={withHeader}
         queryKey={queryKey}
         refreshToken={refreshToken}
+        initialError={initialError}
       />
     </div>
   );

--- a/apps/statgpt-admin-frontend/src/components/TermsView/TermsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/TermsView/TermsView.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { EntityOperation } from '@/src/constants/columns/action';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { ChannelTerm } from '@/src/models/channel';
 import { GridOptions } from 'ag-grid-community';
 import { TermsActionColumn } from './ActionColumn/ActionColumn';
@@ -22,6 +23,7 @@ interface Props {
 }
 
 export const TermsView: FC<Props> = ({ selectedChannelId }) => {
+  const withNotification = useApiNotification();
   const [isLoading, setIsLoading] = useState(false);
   const [isAddView, setIsLoadingAddView] = useState(false);
   const [terms, setTerms] = useState<ChannelTerm[]>([]);
@@ -31,8 +33,13 @@ export const TermsView: FC<Props> = ({ selectedChannelId }) => {
 
   const remove = (data: ChannelTerm) => {
     setIsLoading(true);
-    removeChannelTerm(data?.id?.toString() as string).then(() => {
-      setTerms(terms.filter((t) => t.id !== data.id));
+    withNotification(
+      removeChannelTerm(data?.id?.toString() as string),
+      'Delete Term Failed',
+    ).then((result) => {
+      if (result.ok) {
+        setTerms(terms.filter((t) => t.id !== data.id));
+      }
       setIsLoading(false);
     });
   };
@@ -40,21 +47,25 @@ export const TermsView: FC<Props> = ({ selectedChannelId }) => {
   const saveTerms = () => {
     setIsLoading(true);
     const isAdd = !terms.some((t) => t.id === editableTerm?.id);
-    (isAdd
-      ? addTerm(selectedChannelId, editableTerm as ChannelTerm)
-      : updateChannelTerms(editableTerm as ChannelTerm)
-    ).then(() => {
-      if (isAdd) {
-        setTerms([...terms, editableTerm as ChannelTerm]);
-      } else {
-        setTerms(
-          terms.map((t) =>
-            t.id === editableTerm?.id ? (editableTerm as ChannelTerm) : t,
-          ),
-        );
+    withNotification(
+      isAdd
+        ? addTerm(selectedChannelId, editableTerm as ChannelTerm)
+        : updateChannelTerms(editableTerm as ChannelTerm),
+      'Save Term Failed',
+    ).then((result) => {
+      if (result.ok) {
+        if (isAdd) {
+          setTerms([...terms, editableTerm as ChannelTerm]);
+        } else {
+          setTerms(
+            terms.map((t) =>
+              t.id === editableTerm?.id ? (editableTerm as ChannelTerm) : t,
+            ),
+          );
+        }
+        setIsLoadingAddView(false);
+        setEditableTerm(undefined);
       }
-      setIsLoadingAddView(false);
-      setEditableTerm(undefined);
       setIsLoading(false);
     });
   };
@@ -111,8 +122,11 @@ export const TermsView: FC<Props> = ({ selectedChannelId }) => {
 
   useEffect(() => {
     setIsLoading(true);
-    getChannelTerms(selectedChannelId).then((terms) => {
-      setTerms(terms || []);
+    withNotification(
+      getChannelTerms(selectedChannelId),
+      'Failed to Load Terms',
+    ).then((result) => {
+      setTerms(result.ok ? result.data : []);
       setIsLoading(false);
     });
   }, [selectedChannelId]);

--- a/apps/statgpt-admin-frontend/src/hooks/use-api-notification.ts
+++ b/apps/statgpt-admin-frontend/src/hooks/use-api-notification.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useRef } from 'react';
+import { useNotification } from '@/src/context/NotificationContext';
+import { ApiResult } from '@/src/server/api';
+import { NotificationType } from '@/src/models/notification';
+
+export function useApiNotification() {
+  const { showNotification } = useNotification();
+
+  // Keep a ref to always call the latest showNotification without recreating the
+  // returned function on every render (generic functions can't use useCallback).
+  const showNotificationRef = useRef(showNotification);
+  showNotificationRef.current = showNotification;
+
+  const withNotificationRef = useRef(async function withNotification<R>(
+    request: Promise<ApiResult<R>>,
+    errorTitle = 'Request failed',
+  ): Promise<ApiResult<R>> {
+    const result = await request;
+    if (!result.ok) {
+      showNotificationRef.current({
+        type: NotificationType.error,
+        title: errorTitle,
+        description: result.error.message,
+      });
+    }
+    return result;
+  });
+
+  return withNotificationRef.current;
+}

--- a/apps/statgpt-admin-frontend/src/hooks/use-yaml-parser.ts
+++ b/apps/statgpt-admin-frontend/src/hooks/use-yaml-parser.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback } from 'react';
+import { parse } from 'yaml';
+
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
+
+type ParseResult<T = Record<string, unknown>> =
+  | { ok: true; value: T }
+  | { ok: false };
+
+/**
+ * Returns a stable `parseYaml` function that parses a YAML string and
+ * automatically shows an error toast notification on invalid syntax.
+ */
+export function useYamlParser() {
+  const { showNotification } = useNotification();
+
+  return useCallback(
+    <T = Record<string, unknown>>(raw: string): ParseResult<T> => {
+      try {
+        return { ok: true, value: parse(raw) as T };
+      } catch (e) {
+        showNotification({
+          type: NotificationType.error,
+          title: 'Invalid Configuration',
+          description:
+            e instanceof Error
+              ? e.message
+              : 'YAML syntax error in configuration.',
+        });
+        return { ok: false };
+      }
+    },
+    [showNotification],
+  );
+}

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -32,55 +32,29 @@ export const sendPostRequest = <T extends object, R>(
   dto?: T,
   qs?: Record<string, string>,
   initHeaders?: HeadersInit,
-): Promise<R | null> => {
-  return sendRequest(url, 'POST', dto, qs, initHeaders);
-};
-
-export const sendPutRequest = <T extends object, R>(
-  url: string,
-  dto?: T,
-  qs?: Record<string, string>,
-  initHeaders?: HeadersInit,
-): Promise<R | null> => {
-  return sendRequest(url, 'PUT', dto, qs, initHeaders);
-};
-
-export const sendGetRequest = <T extends object, R>(
-  url: string,
-  dto?: T,
-  qs?: Record<string, string>,
-  initHeaders?: HeadersInit,
-): Promise<R | null> => {
-  return sendRequest(url, 'GET', dto, qs, initHeaders);
-};
-
-export const sendDeleteRequest = <R>(url: string): Promise<R | null> => {
-  return sendRequest(url, 'DELETE');
-};
-
-export const sendPostRequestSafe = <T extends object, R>(
-  url: string,
-  dto?: T,
-  qs?: Record<string, string>,
-  initHeaders?: HeadersInit,
 ): Promise<ApiResult<R>> => {
   return sendRequestSafe(url, 'POST', dto, qs, initHeaders);
 };
 
-export const sendPutRequestSafe = <T extends object, R>(
+export const sendGetRequest = <R extends object>(
   url: string,
-  dto?: T,
-  qs?: Record<string, string>,
-  initHeaders?: HeadersInit,
 ): Promise<ApiResult<R>> => {
-  return sendRequestSafe(url, 'PUT', dto, qs, initHeaders);
+  return sendRequestSafe<object, R>(url, 'GET');
 };
 
-export const sendDeleteRequestSafe = <R>(
-  url: string,
-): Promise<ApiResult<R>> => {
-  return sendRequestSafe(url, 'DELETE');
+export const sendDeleteRequest = <R>(url: string): Promise<ApiResult<R>> => {
+  return sendRequestSafe<object, R>(url, 'DELETE');
 };
+
+export function apiResultToResponse<R>(result: ApiResult<R>): Response {
+  if (!result.ok) {
+    return Response.json(
+      { error: result.error.message },
+      { status: result.error.status || 500 },
+    );
+  }
+  return Response.json(result.data);
+}
 
 export const streamRequest = async (
   url: string,
@@ -120,40 +94,6 @@ export const streamRequest = async (
   } catch (e) {
     console.error('Error', e);
     return Response.json({ error: 'Proxy error' }, { status: 500 });
-  }
-};
-
-export const sendRequest = async <T extends object, R>(
-  url: string,
-  type: string,
-  dto?: T,
-  qs?: Record<string, string>,
-  initHeaders?: HeadersInit,
-  token?: JWT | null,
-): Promise<R | null> => {
-  try {
-    return fetch(url, {
-      body: dto instanceof FormData ? dto : JSON.stringify(dto),
-      method: type,
-      cache: 'no-store',
-      headers: {
-        ...initHeaders,
-        ...getApiHeaders({ jwt: token?.access_token }, dto instanceof FormData),
-      },
-    }).then((r) => {
-      if (!(r.status >= 200 && r.status < 300)) {
-        console.error('Request error Url', r.url);
-
-        return r.text().then((text) => {
-          console.error('Request error', r.status, text);
-          return null;
-        });
-      }
-      return (type === 'DELETE' ? r.text() : r.json()) as Promise<R>;
-    });
-  } catch (e) {
-    console.error('Error', e);
-    return Promise.resolve(null);
   }
 };
 

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -7,7 +7,6 @@ export const ADMIN = '';
 export const API = 'api/v1';
 export const MAIN_API = `${ADMIN}/${API}`;
 
-export const CACHE: RequestInit = { cache: 'no-store' };
 const PREVIEW_BODY_LENGTH = 1000;
 
 export interface ApiError {

--- a/apps/statgpt-admin-frontend/src/server/audit-logs-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/audit-logs-api.ts
@@ -6,7 +6,7 @@ import {
 } from '@/src/models/audit-log';
 import { JWT } from 'next-auth/jwt';
 import { RequestData } from '@/src/models/request-data';
-import { MAIN_API } from './api';
+import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
 import { mapAuditLogRequestToQueryString } from '../utils/audit-logs';
 
@@ -20,7 +20,7 @@ export class AuditLogsApi extends BaseApi {
   getAuditLogs(
     token: JWT | null,
     params?: AuditLogRequestModel,
-  ): Promise<RequestData<AuditLog> | null> {
+  ): Promise<ApiResult<RequestData<AuditLog>>> {
     let url = AUDIT_LOGS_URL;
 
     if (params) {
@@ -36,7 +36,7 @@ export class AuditLogsApi extends BaseApi {
   getAuditLogById(
     id: string,
     token: JWT | null,
-  ): Promise<RequestData<AuditLogDetails> | null> {
+  ): Promise<ApiResult<RequestData<AuditLogDetails>>> {
     return this.get(AUDIT_LOGS_ID_URL(id), token);
   }
 
@@ -53,7 +53,7 @@ export class AuditLogsApi extends BaseApi {
     return this.streamRequest(url, token);
   }
 
-  getEnumValues(token: JWT | null): Promise<AuditLogEnumValues | null> {
+  getEnumValues(token: JWT | null): Promise<ApiResult<AuditLogEnumValues>> {
     return this.get(ENUM_VALUES_URL, token);
   }
 }

--- a/apps/statgpt-admin-frontend/src/server/base-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/base-api.ts
@@ -1,5 +1,6 @@
 import { JWT } from 'next-auth/jwt';
-import { ApiResult, sendRequest, sendRequestSafe, streamRequest } from './api';
+import { getApiHeaders } from '@/src/utils/auth/api-headers';
+import { ApiResult, sendRequestSafe, streamRequest } from './api';
 
 export interface BaseApiConfig {
   host?: string;
@@ -15,34 +16,7 @@ export class BaseApi {
     this.config = config;
   }
 
-  protected async delete<T extends object, R>(
-    url: string,
-    token?: JWT | null,
-  ): Promise<R | null> {
-    return this.sendRequest<T, R>(url, 'DELETE', void 0, void 0, void 0, token);
-  }
-
-  protected async put<T extends object, R>(
-    url: string,
-    dto: T,
-    qs?: Record<string, string>,
-    initHeaders?: HeadersInit,
-    token?: JWT | null,
-  ): Promise<R | null> {
-    return this.sendRequest<T, R>(url, 'PUT', dto, qs, initHeaders, token);
-  }
-
-  protected async post<T extends object, R>(
-    url: string,
-    dto: T,
-    qs?: Record<string, string>,
-    initHeaders?: HeadersInit,
-    token?: JWT | null,
-  ): Promise<R | null> {
-    return this.sendRequest<T, R>(url, 'POST', dto, qs, initHeaders, token);
-  }
-
-  protected async deleteSafe<T extends object, R>(
+  protected delete<T extends object, R>(
     url: string,
     token?: JWT | null,
   ): Promise<ApiResult<R>> {
@@ -56,7 +30,7 @@ export class BaseApi {
     );
   }
 
-  protected async putSafe<T extends object, R>(
+  protected put<T extends object, R>(
     url: string,
     dto: T,
     qs?: Record<string, string>,
@@ -66,7 +40,7 @@ export class BaseApi {
     return this.sendRequestSafe<T, R>(url, 'PUT', dto, qs, initHeaders, token);
   }
 
-  protected async postSafe<T extends object, R>(
+  protected post<T extends object, R>(
     url: string,
     dto: T,
     qs?: Record<string, string>,
@@ -84,6 +58,22 @@ export class BaseApi {
     url: string,
     token?: JWT | null,
     tempUrl = false,
+  ): Promise<ApiResult<R>> {
+    return this.sendRequestSafe<object, R>(
+      url,
+      'GET',
+      void 0,
+      void 0,
+      void 0,
+      token,
+      tempUrl,
+    );
+  }
+
+  protected getRaw<R extends object>(
+    url: string,
+    token?: JWT | null,
+    tempUrl = false,
   ): Promise<R | null> {
     return this.sendRequest<object, R>(
       url,
@@ -96,11 +86,11 @@ export class BaseApi {
     );
   }
 
-  private sendRequest<T extends object, R>(
+  private async sendRequest<T extends object, R>(
     url: string,
     type: string,
     dto?: T,
-    qs?: Record<string, string>,
+    _qs?: Record<string, string>,
     initHeaders?: HeadersInit,
     token?: JWT | null,
     tempUrl = false,
@@ -108,15 +98,32 @@ export class BaseApi {
     const apiKey = this.config.dialKey
       ? { 'Api-key': this.config.dialKey }
       : {};
-
-    return sendRequest(
-      `${tempUrl ? this.config.dialTemp : this.config.host || this.config.dial}${url}`,
-      type,
-      dto,
-      qs,
-      { ...initHeaders, ...apiKey } as HeadersInit,
-      token,
-    );
+    const fullUrl = `${tempUrl ? this.config.dialTemp : this.config.host || this.config.dial}${url}`;
+    try {
+      const r = await fetch(fullUrl, {
+        body: dto instanceof FormData ? dto : JSON.stringify(dto),
+        method: type,
+        cache: 'no-store',
+        headers: {
+          ...initHeaders,
+          ...apiKey,
+          ...getApiHeaders(
+            { jwt: token?.access_token },
+            dto instanceof FormData,
+          ),
+        } as HeadersInit,
+      });
+      if (!(r.status >= 200 && r.status < 300)) {
+        console.error('Request error Url', r.url);
+        const text = await r.text();
+        console.error('Request error', r.status, text);
+        return null;
+      }
+      return (type === 'DELETE' ? await r.text() : await r.json()) as R;
+    } catch (e) {
+      console.error('Error', e);
+      return null;
+    }
   }
 
   private sendRequestSafe<T extends object, R>(

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -13,7 +13,7 @@ import {
 import { Channel, ChannelTerm } from '@/src/models/channel';
 import { DataSet } from '@/src/models/data-sets';
 import { RequestData } from '@/src/models/request-data';
-import { MAIN_API } from './api';
+import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
 import { Job, JobStatus } from '@/src/models/job';
 
@@ -58,56 +58,97 @@ export const RELOAD_DATASET_CHANNEL_URL = (
 ): string => `${DATASET_CHANNEL_URL(id, dsId)}/reload-indicators`;
 
 export class ChannelsApi extends BaseApi {
-  getChannels(token: JWT | null): Promise<RequestData<Channel> | null> {
+  getChannels(token: JWT | null): Promise<ApiResult<RequestData<Channel>>> {
     return this.get(CHANNELS_URL, token);
   }
 
-  exportChannel(
+  async exportChannel(
     id: string,
     token: JWT | null,
-  ): Promise<{ ok: boolean; res?: unknown }> {
-    return this.post(CHANNEL_ID_EXPORT_URL(id), {}, void 0, void 0, token).then(
-      (res) => {
-        const id = (res as Job).id;
+  ): Promise<ApiResult<string>> {
+    const initResult = await this.post(
+      CHANNEL_ID_EXPORT_URL(id),
+      {},
+      void 0,
+      void 0,
+      token,
+    );
 
-        return firstValueFrom(this.waitForJobReady(id, token).pipe()).then(
-          (res) => {
-            if ((res as Job).status === JobStatus.FAILED) {
-              return { ok: false, res: (res as Job).reason_for_failure };
-            } else {
-              return { ok: true, res: `api/v1/channels/download/${id}` };
-            }
-          },
-        );
+    if (!initResult.ok) {
+      return initResult;
+    }
+
+    const jobId = (initResult.data as Job).id;
+
+    return firstValueFrom(this.waitForJobReady(jobId, token).pipe()).then(
+      (res) => {
+        if (res === null) {
+          return {
+            ok: false,
+            error: {
+              status: 500,
+              message: 'Failed to check export job status',
+            },
+          } as ApiResult<string>;
+        }
+        if ((res as Job).status === JobStatus.FAILED) {
+          return {
+            ok: false,
+            error: {
+              status: 500,
+              message: (res as Job).reason_for_failure || 'Export job failed',
+            },
+          } as ApiResult<string>;
+        }
+        return { ok: true, data: `api/v1/channels/download/${jobId}` };
       },
     );
   }
 
-  importChannel(
+  async importChannel(
     formData: FormData,
     updateDatasets: boolean,
     updateDataSources: boolean,
     cleanUp: boolean,
     token: JWT | null,
-  ): Promise<{ ok: boolean; res?: unknown }> {
-    return this.post(
+  ): Promise<ApiResult<null>> {
+    const initResult = await this.post(
       `${CHANNELS_IMPORT_URL}?update_data_sources=${updateDataSources}&update_datasets=${updateDatasets}&clean_up=${cleanUp}`,
       formData,
       void 0,
       void 0,
       token,
-    ).then((res) => {
-      const id = (res as Job).id;
+    );
 
-      return firstValueFrom(this.waitForJobReady(id, token).pipe()).then(
-        (res) => {
-          if ((res as Job).status === JobStatus.FAILED) {
-            return { ok: false, res: (res as Job).reason_for_failure };
-          }
-          return { ok: true };
-        },
-      );
-    });
+    if (!initResult.ok) {
+      return initResult;
+    }
+
+    const jobId = (initResult.data as Job).id;
+
+    return firstValueFrom(this.waitForJobReady(jobId, token).pipe()).then(
+      (res) => {
+        if (res === null) {
+          return {
+            ok: false,
+            error: {
+              status: 500,
+              message: 'Failed to check import job status',
+            },
+          } as ApiResult<null>;
+        }
+        if ((res as Job).status === JobStatus.FAILED) {
+          return {
+            ok: false,
+            error: {
+              status: 500,
+              message: (res as Job).reason_for_failure || 'Import job failed',
+            },
+          } as ApiResult<null>;
+        }
+        return { ok: true, data: null };
+      },
+    );
   }
 
   downloadFile(id: string, token: JWT | null) {
@@ -117,10 +158,10 @@ export class ChannelsApi extends BaseApi {
   private waitForJobReady(id: number, token: JWT | null) {
     return race(interval(2000)).pipe(
       concatMap(() => {
-        return this.get(CHANNELS_JOB_ID_URL(id), token);
+        return this.getRaw(CHANNELS_JOB_ID_URL(id), token);
       }),
       filter((res) => {
-        console.error('Preparing job', (res as Job).status);
+        if (res === null) return true;
         return (
           (res as Job).status === JobStatus.COMPLETED ||
           (res as Job).status === JobStatus.FAILED
@@ -135,29 +176,35 @@ export class ChannelsApi extends BaseApi {
     );
   }
 
-  getChannel(id: string, token: JWT | null): Promise<Channel | null> {
+  getChannel(id: string, token: JWT | null): Promise<ApiResult<Channel>> {
     return this.get(CHANNEL_ID_URL(id), token);
   }
 
   getChannelTerms(
     id: string,
     token: JWT | null,
-  ): Promise<ChannelTerm[] | null> {
-    return this.get(`${CHANNEL_TERMS_URL(id)}?limit=1000&offset=0`, token).then(
-      (res) => (res as { data: ChannelTerm[] }).data,
+  ): Promise<ApiResult<ChannelTerm[]>> {
+    return this.get<{ data: ChannelTerm[] }>(
+      `${CHANNEL_TERMS_URL(id)}?limit=1000&offset=0`,
+      token,
+    ).then((result) =>
+      result.ok ? { ok: true, data: result.data.data } : result,
     );
   }
 
-  getChannelJobs(id: string, token: JWT | null): Promise<Job[] | null> {
-    return this.get(`${CHANNEL_JOBS_URL(id)}?limit=1000&offset=0`, token).then(
-      (res) => (res as { data: Job[] }).data,
+  getChannelJobs(id: string, token: JWT | null): Promise<ApiResult<Job[]>> {
+    return this.get<{ data: Job[] }>(
+      `${CHANNEL_JOBS_URL(id)}?limit=1000&offset=0`,
+      token,
+    ).then((result) =>
+      result.ok ? { ok: true, data: result.data.data } : result,
     );
   }
 
   updateChannelTerms(
     term: ChannelTerm,
     token: JWT | null,
-  ): Promise<ChannelTerm[] | null> {
+  ): Promise<ApiResult<ChannelTerm[]>> {
     return this.post(
       `${MAIN_API}/terms/${term.id}`,
       term,
@@ -170,7 +217,7 @@ export class ChannelsApi extends BaseApi {
   removeChannelTerms(
     id: string,
     token: JWT | null,
-  ): Promise<ChannelTerm[] | null> {
+  ): Promise<ApiResult<string>> {
     return this.delete(`${CHANNEL_TERMS_URL(id)}/bulk`, token);
   }
 
@@ -178,18 +225,18 @@ export class ChannelsApi extends BaseApi {
     id: string,
     term: ChannelTerm,
     token: JWT | null,
-  ): Promise<ChannelTerm[] | null> {
+  ): Promise<ApiResult<ChannelTerm[]>> {
     return this.post(CHANNEL_TERMS_URL(id), term, void 0, void 0, token);
   }
 
-  removeChannelTerm(
-    id: string,
-    token: JWT | null,
-  ): Promise<ChannelTerm[] | null> {
+  removeChannelTerm(id: string, token: JWT | null): Promise<ApiResult<string>> {
     return this.delete(`${MAIN_API}/terms/${id}`, token);
   }
 
-  updateChannel(channel: Channel, token: JWT | null): Promise<Channel | null> {
+  updateChannel(
+    channel: Channel,
+    token: JWT | null,
+  ): Promise<ApiResult<Channel>> {
     return this.post(
       CHANNEL_ID_URL(channel.id),
       channel,
@@ -202,14 +249,14 @@ export class ChannelsApi extends BaseApi {
   getChannelDataset(
     id: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.get(`${CHANNEL_DATA_SETS_URL(id)}?limit=500`, token);
   }
 
   deduplicateDataset(
     id: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.post(CHANNEL_DEDUPLICATE_URL(id), {}, void 0, {}, token);
   }
 
@@ -217,7 +264,7 @@ export class ChannelsApi extends BaseApi {
     id: string,
     dataSetId: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<string>> {
     return this.delete(DATASET_CHANNEL_URL(id, dataSetId), token);
   }
 
@@ -225,7 +272,7 @@ export class ChannelsApi extends BaseApi {
     id: string,
     dataSetId: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.post(
       DATASET_CHANNEL_URL(id, dataSetId),
       {},
@@ -239,7 +286,7 @@ export class ChannelsApi extends BaseApi {
     id: string,
     dataSetId: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.post(
       RELOAD_DATASET_CHANNEL_URL(id, dataSetId),
       {},
@@ -252,7 +299,7 @@ export class ChannelsApi extends BaseApi {
   reloadDataSets(
     id: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.post(
       RELOAD_ALL_DATASETS_CHANNEL_URL(id),
       {},
@@ -262,11 +309,14 @@ export class ChannelsApi extends BaseApi {
     );
   }
 
-  createChannel(channel: Channel, token: JWT | null): Promise<Channel | null> {
+  createChannel(
+    channel: Channel,
+    token: JWT | null,
+  ): Promise<ApiResult<Channel>> {
     return this.post(CHANNELS_URL, channel, void 0, void 0, token);
   }
 
-  removeChannel(id: string, token: JWT | null): Promise<unknown> {
+  removeChannel(id: string, token: JWT | null): Promise<ApiResult<string>> {
     return this.delete(`${CHANNELS_URL}/${id}`, token);
   }
 }

--- a/apps/statgpt-admin-frontend/src/server/data-sets-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/data-sets-api.ts
@@ -14,36 +14,29 @@ export const RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL = (id?: string | number) =>
   `${DATA_SETS_WITH_ID_URL(id)}/reload-dimensions`;
 
 export class DataSetsApi extends BaseApi {
-  getDataSets(token: JWT | null): Promise<RequestData<DataSet> | null> {
+  getDataSets(token: JWT | null): Promise<ApiResult<RequestData<DataSet>>> {
     return this.get(`${DATA_SETS_URL}?limit=500`, token);
   }
 
   createDataSet(
     ds: DataSet,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.post(DATA_SETS_URL, ds, void 0, void 0, token);
   }
 
-  createDataSetSafe(
-    ds: DataSet,
-    token: JWT | null,
-  ): Promise<ApiResult<RequestData<DataSet>>> {
-    return this.postSafe(DATA_SETS_URL, ds, void 0, void 0, token);
-  }
-
-  removeDataSet(id: string, token: JWT | null): Promise<unknown> {
+  removeDataSet(id: string, token: JWT | null): Promise<ApiResult<string>> {
     return this.delete(`${DATA_SETS_URL}/${id}`, token);
   }
 
-  updateDataSet(ds: DataSet, token: JWT | null): Promise<DataSet | null> {
+  updateDataSet(ds: DataSet, token: JWT | null): Promise<ApiResult<DataSet>> {
     return this.post(DATA_SETS_WITH_ID_URL(ds.id), ds, void 0, void 0, token);
   }
 
   reloadDimensionsDataSet(
     id: string,
     token: JWT | null,
-  ): Promise<DataSet | null> {
+  ): Promise<ApiResult<DataSet>> {
     return this.post(
       RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL(id),
       {},

--- a/apps/statgpt-admin-frontend/src/server/data-sources-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/data-sources-api.ts
@@ -3,7 +3,7 @@ import { JWT } from 'next-auth/jwt';
 import { DataSet } from '@/src/models/data-sets';
 import { DataSource, DataSourceType } from '@/src/models/data-source';
 import { RequestData } from '@/src/models/request-data';
-import { MAIN_API } from './api';
+import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
 
 export const DATA_SOURCE_URL = `${MAIN_API}/data-sources`;
@@ -16,38 +16,40 @@ export const LOAD_AVAILABLE_DATA_SET_URL = (id?: number | string) =>
   `${DATA_SOURCE_WITH_ID_URL(id)}/available-datasets`;
 
 export class DataSourcesApi extends BaseApi {
-  getDataSources(token: JWT | null): Promise<RequestData<DataSource> | null> {
+  getDataSources(
+    token: JWT | null,
+  ): Promise<ApiResult<RequestData<DataSource>>> {
     return this.get(DATA_SOURCE_URL, token);
   }
 
   getDataSourcesTypes(
     token: JWT | null,
-  ): Promise<RequestData<DataSourceType> | null> {
+  ): Promise<ApiResult<RequestData<DataSourceType>>> {
     return this.get(DATA_SOURCE_TYPE_URL, token);
   }
 
   createDataSource(
     ds: DataSource,
     token: JWT | null,
-  ): Promise<DataSource | null> {
+  ): Promise<ApiResult<DataSource>> {
     return this.post(DATA_SOURCE_URL, ds, void 0, void 0, token);
   }
 
   updateDataSources(
     ds: DataSource,
     token: JWT | null,
-  ): Promise<DataSource | null> {
+  ): Promise<ApiResult<DataSource>> {
     return this.post(DATA_SOURCE_WITH_ID_URL(ds.id), ds, void 0, void 0, token);
   }
 
-  removeDataSource(id: string, token: JWT | null): Promise<unknown> {
+  removeDataSource(id: string, token: JWT | null): Promise<ApiResult<string>> {
     return this.delete(DATA_SOURCE_WITH_ID_URL(id), token);
   }
 
   loadAvailableDataSets(
     id: string,
     token: JWT | null,
-  ): Promise<RequestData<DataSet> | null> {
+  ): Promise<ApiResult<RequestData<DataSet>>> {
     return this.get(LOAD_AVAILABLE_DATA_SET_URL(id), token);
   }
 }

--- a/apps/statgpt-admin-frontend/src/server/documents-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/documents-api.ts
@@ -12,6 +12,7 @@ import {
 
 import { Document, DocumentMetadata } from '@/src/models/document';
 import { RequestData } from '@/src/models/request-data';
+import { ApiResult } from './api';
 import { BaseApi } from './base-api';
 
 export const DIAL_DOCUMENTS_INDEX_LIST = `/indexing`;
@@ -30,38 +31,48 @@ enum TaskStatus {
   SUCCESS = 'SUCCESS',
 }
 export class DocumentsApi extends BaseApi {
-  getList(token: JWT | null): Promise<RequestData<Document> | null> {
+  getList(token: JWT | null): Promise<ApiResult<RequestData<Document>>> {
     return this.get(`${DIAL_DOCUMENTS_LIST}?limit=2000`, token);
   }
 
-  removeDocument(id: string): Promise<RequestData<Document> | null> {
+  removeDocument(id: string): Promise<ApiResult<string>> {
     return this.delete(`${DIAL_DOCUMENTS_LIST}/${id}`);
   }
 
-  getMetaData(): Promise<DocumentMetadata | null> {
+  getMetaData(): Promise<ApiResult<DocumentMetadata>> {
     return this.get(DIAL_DOCUMENTS_METADATA_LIST);
   }
 
-  uploadFile(formData: FormData, targetPath?: string): Promise<unknown> {
-    return this.post(
+  async uploadFile(
+    formData: FormData,
+    targetPath?: string,
+  ): Promise<ApiResult<void>> {
+    const initResult = await this.post<FormData, Task>(
       `${DOCUMENT_UPLOAD_URL}?${targetPath ? `target_path=${targetPath}&` : ''}async=${true}&use_cache=${true}`,
       formData,
       { overwrite: 'true' },
-    ).then((res) => {
-      const id = (res as Task).task_id;
+    );
 
-      return firstValueFrom(this.waitForTaskReady(id).pipe()).then((res) => {
-        return (res as Task).status === TaskStatus.FAILED
-          ? { ok: false }
-          : { ok: true };
-      });
+    if (!initResult.ok) {
+      return initResult;
+    }
+
+    const id = initResult.data.task_id;
+
+    return firstValueFrom(this.waitForTaskReady(id).pipe()).then((res) => {
+      return (res as Task).status === TaskStatus.FAILED
+        ? {
+            ok: false,
+            error: { status: 500, message: 'File upload processing failed' },
+          }
+        : { ok: true, data: undefined };
     });
   }
 
   private waitForTaskReady(id: string) {
     return race(interval(2000)).pipe(
       concatMap(() => {
-        return this.get(`${DOCUMENT_TASK_URL}/${id}`);
+        return this.getRaw(`${DOCUMENT_TASK_URL}/${id}`);
       }),
       filter((res) => {
         return (


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/109

### Description of changes

Unified API result type — Replaced the `T | null` return style across all server-side API classes (**ChannelsApi, DataSetsApi, DataSourcesApi, AuditLogsApi, DocumentsApi**) and standalone client helpers (**sendPostRequest, sendGetRequest, sendDeleteRequest**) with a discriminated union `ApiResult<R> ({ ok: true; data: R } | { ok: false; error: ApiError })`. Removed the old Safe-postfix duplicates.

BFF routes now forward real HTTP status codes — Added `apiResultToResponse()` helper used in all **/api/v1/*** route handlers. Previously every upstream error was silently wrapped in a 200 response; now backend errors propagate their actual status (4xx/5xx) to the client.

Client-side notification hook — Added **useApiNotification** hook that wraps any `Promise<ApiResult<R>>` call and automatically shows an error toast on failure, removing scattered **showNotification** boilerplate from ~12 components.

Server component errors surfaced to the UI — Page-level data load failures (initial fetch in **data-sources, data-sets, documents, channels, audit-logs** pages) now pass the error message as an initialError prop to the first client component, which shows a toast on mount.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
