### PR TITLE
feat: remove recalculate index action from datasets grid

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
@@ -20,7 +20,6 @@ import { BaseEntity, BaseEntityWithDetails } from '@/src/models/base-entity';
 import { DataSet } from '@/src/models/data-sets';
 import { sendDeleteRequest, sendPostRequest } from '@/src/server/api';
 import { CHANNEL_DATA_SETS_URL } from '@/src/server/channels-api';
-import { RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL } from '@/src/server/data-sets-api';
 import { getDeleteDescription, getDeleteTitle, getUrl } from './utils';
 import { useNotification } from '@/src/context/NotificationContext';
 import { NotificationType } from '../../../models/notification';
@@ -106,17 +105,6 @@ export const ActionColumn: FC<Props> = ({
   };
 
   const recalculateDataSet = () => {
-    if (listView === Menu.DATA_SETS) {
-      withNotification(
-        sendPostRequest(RELOAD_DIMENSIONS_DATA_SETS_WITH_ID_URL(data.id), {}),
-        'Recalculate Failed',
-      ).then((result) => {
-        if (result.ok) {
-          close();
-        }
-      });
-    }
-
     if (listView === Menu.CHANNELS) {
       const channelId = pathname.split('/')[2];
       withNotification(

--- a/apps/statgpt-admin-frontend/src/constants/columns/grid-columns.ts
+++ b/apps/statgpt-admin-frontend/src/constants/columns/grid-columns.ts
@@ -53,7 +53,6 @@ export const DATA_SETS_COLUMNS_WITH_ACTIONS: ColDef[] = [
   ...DATA_SETS_COLUMNS,
   ACTION_COLUMN(Menu.DATA_SETS, [
     EntityOperation.Configure,
-    EntityOperation.RecalculateIndex,
     EntityOperation.Delete,
   ]),
 ];


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Remove the "Recalculate indexes" action from the datasets grid action menu.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
