### PR TITLE
feat: add channel dataset versions page

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/[datasetId]/versions/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/datasets/[datasetId]/versions/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+import { channelsApi } from '../../../../../../api';
+import { apiResultToResponse } from '@/src/server/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ id: string; datasetId: string }> },
+) {
+  try {
+    const params = await context.params;
+    const token = await getToken({ req });
+    return apiResultToResponse(
+      await channelsApi.getChannelDatasetVersions(
+        params.id,
+        params.datasetId,
+        token,
+      ),
+    );
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/versions/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/versions/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { DatasetVersions } from '@/src/components/ChannelView/DatasetVersions/DatasetVersions';
+
+export const dynamic = 'force-dynamic';
+
+export default function Page() {
+  const params = useParams();
+
+  return (
+    <DatasetVersions
+      channelId={params.id as string}
+      datasetId={params.datasetId as string}
+    />
+  );
+}

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/DatasetVersions/DatasetVersions.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/DatasetVersions/DatasetVersions.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+
+import { GridView } from '@/src/components/GridView/GridView';
+import { useAccessControl } from '@/src/context/AccessControlContext';
+import { ChannelDatasetVersion } from '@/src/models/channel-dataset-version';
+import { RequestData } from '@/src/models/request-data';
+import { sendGetRequest } from '@/src/server/api';
+import {
+  CHANNEL_DATA_SETS_URL,
+  CHANNEL_DATASET_VERSIONS_URL,
+} from '@/src/server/channels-api';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { ChannelDataset } from '@/src/models/channel-dataset';
+
+interface Props {
+  channelId: string;
+  datasetId: string;
+}
+
+const GRID_COLUMNS = [
+  { field: 'version', headerName: 'Version', filter: 'agNumberColumnFilter' },
+  {
+    field: 'preprocessing_status',
+    headerName: 'Status',
+    filter: 'agTextColumnFilter',
+  },
+  {
+    field: 'creation_reason',
+    headerName: 'Creation Reason',
+    filter: 'agTextColumnFilter',
+  },
+  {
+    field: 'reason_for_failure',
+    headerName: 'Failure Reason',
+    filter: 'agTextColumnFilter',
+  },
+  {
+    field: 'created_at',
+    headerName: 'Created At',
+    filter: 'agTextColumnFilter',
+    valueFormatter: ({ value }: { value: string | null }) =>
+      value ? new Date(value).toLocaleString() : '',
+  },
+  {
+    field: 'updated_at',
+    headerName: 'Updated At',
+    filter: 'agTextColumnFilter',
+    valueFormatter: ({ value }: { value: string | null }) =>
+      value ? new Date(value).toLocaleString() : '',
+  },
+];
+
+export const DatasetVersions: FC<Props> = ({ channelId, datasetId }) => {
+  const withNotification = useApiNotification();
+  const { setForbidden } = useAccessControl();
+
+  const [versions, setVersions] = useState<ChannelDatasetVersion[]>([]);
+  const [datasetTitle, setDatasetTitle] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!channelId || !datasetId) return;
+
+    sendGetRequest<RequestData<ChannelDataset>>(
+      CHANNEL_DATA_SETS_URL(channelId),
+    ).then((result) => {
+      if (result.ok) {
+        const match = result.data.data.find(
+          (ds) => String(ds.dataset_id) === datasetId,
+        );
+        if (match) setDatasetTitle(match.dataset.title);
+      }
+    });
+  }, [channelId, datasetId]);
+
+  useEffect(() => {
+    if (!channelId || !datasetId || isLoading) return;
+
+    setIsLoading(true);
+    withNotification(
+      sendGetRequest<RequestData<ChannelDatasetVersion>>(
+        CHANNEL_DATASET_VERSIONS_URL(channelId, datasetId),
+      ),
+      'Failed to Load Versions',
+      [403],
+    ).then((result) => {
+      setIsLoading(false);
+      if (!result.ok && result.error.status === 403) {
+        setForbidden();
+        return;
+      }
+      if (result.ok) {
+        setVersions(result.data.data);
+      }
+    });
+  }, [channelId, datasetId]);
+
+  return (
+    <div className="bg-layer-2 flex flex-col h-full common-paddings">
+      <h1 className="mb-4">
+        {datasetTitle ? `${datasetTitle} — Versions` : 'Dataset Versions'}
+      </h1>
+      <div className="flex-1 min-h-0">
+        <GridView
+          data={versions}
+          colDefs={GRID_COLUMNS}
+          emptyDataTitle="No Versions"
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -127,7 +127,11 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
     },
     ACTION_COLUMN(
       Menu.CHANNELS,
-      [EntityOperation.RecalculateIndex, EntityOperation.Delete],
+      [
+        EntityOperation.Versions,
+        EntityOperation.RecalculateIndex,
+        EntityOperation.Delete,
+      ],
       deleteDataSet.bind(this),
     ),
   ];

--- a/apps/statgpt-admin-frontend/src/components/GridView/ActionColumn/ActionItem.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/ActionColumn/ActionItem.tsx
@@ -1,6 +1,7 @@
 import { FC, useCallback } from 'react';
 import {
   IconDownload,
+  IconHistory,
   IconList,
   IconPencilMinus,
   IconRefreshDot,
@@ -33,6 +34,10 @@ export const ActionItem: FC<Props> = ({ item }) => {
 
     if (item === EntityOperation.Terms) {
       return <Terms />;
+    }
+
+    if (item === EntityOperation.Versions) {
+      return <IconHistory width={18} height={18} />;
     }
 
     return <IconTrashX width={18} height={18} />;

--- a/apps/statgpt-admin-frontend/src/components/Header/Header.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Header/Header.tsx
@@ -14,7 +14,8 @@ export const Header = ({ showBreadcrumbs = true }: HeaderProps) => {
   const pathname = usePathname() as MenuUrl;
   const router = useRouter();
 
-  const [, root, selected, postfix] = pathname.split('/');
+  const segments = pathname.split('/').filter(Boolean);
+  const [root, channelId, sub, datasetId, leaf] = segments;
 
   const url = `/${root}` as MenuUrl;
   const breadcrumbs: Breadcrumb[] = [
@@ -26,12 +27,24 @@ export const Header = ({ showBreadcrumbs = true }: HeaderProps) => {
     },
   ];
 
-  if (selected != null && selected !== '') {
-    breadcrumbs.push({ name: selected });
+  if (channelId != null && channelId !== '') {
+    breadcrumbs.push({
+      name: channelId,
+      click: () => router.push(`/channels/${channelId}`),
+    });
   }
 
-  if (postfix != null && postfix !== '') {
-    breadcrumbs.push({ name: postfix === 'jobs' ? 'Jobs' : 'Terms' });
+  if (sub === 'glossary') {
+    breadcrumbs.push({ name: 'Terms' });
+  } else if (sub === 'jobs') {
+    breadcrumbs.push({ name: 'Jobs' });
+  } else if (sub === 'datasets' && datasetId != null && leaf === 'versions') {
+    breadcrumbs.push({
+      name: datasetId,
+      click: () =>
+        router.push(`/channels/${channelId}/datasets/${datasetId}/versions`),
+    });
+    breadcrumbs.push({ name: 'Versions' });
   }
 
   return (

--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
@@ -175,6 +175,13 @@ export const ActionColumn: FC<Props> = ({
               if (item === EntityOperation.Jobs) {
                 router.push(`/channels/${data.id}/jobs`);
               }
+
+              if (item === EntityOperation.Versions) {
+                const channelId = pathname.split('/')[2];
+                router.push(
+                  `/channels/${channelId}/datasets/${data.dataset_id}/versions`,
+                );
+              }
             }}
           />
         ))}

--- a/apps/statgpt-admin-frontend/src/constants/columns/action.ts
+++ b/apps/statgpt-admin-frontend/src/constants/columns/action.ts
@@ -9,6 +9,7 @@ export enum EntityOperation {
   Terms = 'Glossary',
   Jobs = 'Jobs',
   Edit = 'Edit',
+  Versions = 'Versions',
 }
 
 export const ACTION_COLUMN_CELL_RENDERER_KEY = 'actionColumn';

--- a/apps/statgpt-admin-frontend/src/models/channel-dataset-version.ts
+++ b/apps/statgpt-admin-frontend/src/models/channel-dataset-version.ts
@@ -1,0 +1,19 @@
+export interface ChannelDatasetVersion {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  channel_dataset_id: number;
+  version: number;
+  preprocessing_status: string;
+  creation_reason: string;
+  reason_for_failure: string;
+  pointer_to: number;
+  indexing_config_hash: string;
+  structure_metadata: Record<string, unknown>;
+  structure_hash: string;
+  indicator_dimensions_hash: string;
+  non_indicator_dimensions_hash: string;
+  special_dimensions_hash: string;
+  resolved_config: Record<string, unknown>;
+  indexing_stats: Record<string, unknown>;
+}

--- a/apps/statgpt-admin-frontend/src/models/channel-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/channel-dataset.ts
@@ -1,0 +1,9 @@
+export interface ChannelDataset {
+  dataset_id: number;
+  preprocessing_status: string;
+  dataset: {
+    title: string;
+    description: string;
+    data_source: { title: string };
+  };
+}

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -11,6 +11,7 @@ import {
 } from 'rxjs';
 
 import { Channel, ChannelTerm } from '@/src/models/channel';
+import { ChannelDatasetVersion } from '@/src/models/channel-dataset-version';
 import { DataSet } from '@/src/models/data-sets';
 import { RequestData } from '@/src/models/request-data';
 import { ApiResult, MAIN_API } from './api';
@@ -56,6 +57,11 @@ export const RELOAD_DATASET_CHANNEL_URL = (
   id: string | number,
   dsId: string | number,
 ): string => `${DATASET_CHANNEL_URL(id, dsId)}/reload-indicators`;
+
+export const CHANNEL_DATASET_VERSIONS_URL = (
+  channelId: string | number,
+  datasetId: string | number,
+): string => `${DATASET_CHANNEL_URL(channelId, datasetId)}/versions`;
 
 export class ChannelsApi extends BaseApi {
   getChannels(token: JWT | null): Promise<ApiResult<RequestData<Channel>>> {
@@ -292,6 +298,17 @@ export class ChannelsApi extends BaseApi {
       {},
       void 0,
       void 0,
+      token,
+    );
+  }
+
+  getChannelDatasetVersions(
+    channelId: string,
+    datasetId: string,
+    token: JWT | null,
+  ): Promise<ApiResult<RequestData<ChannelDatasetVersion>>> {
+    return this.get(
+      `${CHANNEL_DATASET_VERSIONS_URL(channelId, datasetId)}?limit=500`,
       token,
     );
   }


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/131

### Description of changes

Adds a versions page for channel datasets. Each dataset row in the channel view now has a "Versions" context menu item that navigates to a grid showing the dataset's version history. Breadcrumbs are updated to reflect the new route depth.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
