### PR TITLE
feat: add placeholders to side-menu and breadcrumbs while page is fetching main content

### DIFF
--- a/apps/statgpt-admin-frontend/next-env.d.ts
+++ b/apps/statgpt-admin-frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/statgpt-admin-frontend/src/app/(main)/audit-logs/loading.tsx
+++ b/apps/statgpt-admin-frontend/src/app/(main)/audit-logs/loading.tsx
@@ -1,5 +1,11 @@
+import { LoadingStateSetter } from '@/src/components/LoadingStateSetter/LoadingStateSetter';
 import { PageLoader } from '@/src/components/PageLoader/PageLoader';
 
 export default function Loading() {
-  return <PageLoader />;
+  return (
+    <>
+      <LoadingStateSetter />
+      <PageLoader />
+    </>
+  );
 }

--- a/apps/statgpt-admin-frontend/src/app/(main)/channels/loading.tsx
+++ b/apps/statgpt-admin-frontend/src/app/(main)/channels/loading.tsx
@@ -1,5 +1,11 @@
+import { LoadingStateSetter } from '@/src/components/LoadingStateSetter/LoadingStateSetter';
 import { PageLoader } from '@/src/components/PageLoader/PageLoader';
 
 export default function Loading() {
-  return <PageLoader />;
+  return (
+    <>
+      <LoadingStateSetter />
+      <PageLoader />
+    </>
+  );
 }

--- a/apps/statgpt-admin-frontend/src/app/(main)/data-sets/loading.tsx
+++ b/apps/statgpt-admin-frontend/src/app/(main)/data-sets/loading.tsx
@@ -1,5 +1,11 @@
+import { LoadingStateSetter } from '@/src/components/LoadingStateSetter/LoadingStateSetter';
 import { PageLoader } from '@/src/components/PageLoader/PageLoader';
 
 export default function Loading() {
-  return <PageLoader />;
+  return (
+    <>
+      <LoadingStateSetter />
+      <PageLoader />
+    </>
+  );
 }

--- a/apps/statgpt-admin-frontend/src/app/(main)/data-sources/loading.tsx
+++ b/apps/statgpt-admin-frontend/src/app/(main)/data-sources/loading.tsx
@@ -1,5 +1,11 @@
+import { LoadingStateSetter } from '@/src/components/LoadingStateSetter/LoadingStateSetter';
 import { PageLoader } from '@/src/components/PageLoader/PageLoader';
 
 export default function Loading() {
-  return <PageLoader />;
+  return (
+    <>
+      <LoadingStateSetter />
+      <PageLoader />
+    </>
+  );
 }

--- a/apps/statgpt-admin-frontend/src/app/(main)/documents/loading.tsx
+++ b/apps/statgpt-admin-frontend/src/app/(main)/documents/loading.tsx
@@ -1,5 +1,11 @@
+import { LoadingStateSetter } from '@/src/components/LoadingStateSetter/LoadingStateSetter';
 import { PageLoader } from '@/src/components/PageLoader/PageLoader';
 
 export default function Loading() {
-  return <PageLoader />;
+  return (
+    <>
+      <LoadingStateSetter />
+      <PageLoader />
+    </>
+  );
 }

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/ChannelView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/ChannelView.tsx
@@ -6,6 +6,7 @@ import { useAccessControl } from '@/src/context/AccessControlContext';
 import { getChannel } from '@/src/app/channels/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
 import { Channel } from '@/src/models/channel';
 import { DataSetsView } from './Datasets/Datasets';
 
@@ -21,6 +22,7 @@ export const ChannelView: FC<Props> = ({ selectedChannelId }) => {
   );
 
   const [isLoadingChannel, setIsLoadingChannel] = useState(true);
+  usePageInitialLoadingSync(isLoadingChannel);
 
   useEffect(() => {
     if (selectedChannel == null) {

--- a/apps/statgpt-admin-frontend/src/components/Header/Header.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { MENU_MAP, MenuUrl } from '@/src/constants/menu';
 import { Breadcrumb } from '@/src/models/breadcrumbs';
 import { Breadcrumbs } from '@/src/components/Breadcrumbs/Breadcrumbs';
 import { UserMenu } from '@/src/components/Header/User/UserMenu';
+import { useNavigationLoading } from '@/src/context/NavigationLoadingContext';
 
 interface HeaderProps {
   showBreadcrumbs?: boolean;
@@ -13,6 +14,7 @@ interface HeaderProps {
 export const Header = ({ showBreadcrumbs = true }: HeaderProps) => {
   const pathname = usePathname() as MenuUrl;
   const router = useRouter();
+  const { isLoading } = useNavigationLoading();
 
   const [, root, selected, postfix] = pathname.split('/');
 
@@ -43,7 +45,11 @@ export const Header = ({ showBreadcrumbs = true }: HeaderProps) => {
         </div>
         {showBreadcrumbs && (
           <div className="pl-[36px]">
-            <Breadcrumbs breadcrumbs={breadcrumbs} />
+            {isLoading ? (
+              <div className="h-4 w-32 rounded bg-layer-4 animate-pulse" />
+            ) : (
+              <Breadcrumbs breadcrumbs={breadcrumbs} />
+            )}
           </div>
         )}
       </div>

--- a/apps/statgpt-admin-frontend/src/components/JobsView/JobsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/JobsView/JobsView.tsx
@@ -7,6 +7,7 @@ import { getChannelJobs } from '@/src/app/channels/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
 import { Job } from '@/src/models/job';
 import { ColDef } from 'ag-grid-community';
 import { JobsActionColumn } from './ActionColumn';
@@ -18,8 +19,9 @@ interface Props {
 export const JobsView: FC<Props> = ({ selectedChannelId }) => {
   const { setForbidden } = useAccessControl();
   const withNotification = useApiNotification();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [jobs, setJobs] = useState<Job[]>([]);
+  usePageInitialLoadingSync(isLoading);
 
   const columns: ColDef[] = [
     {

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
@@ -14,6 +14,8 @@ import {
 import { ListHeader } from '../ListHeader/ListHeader';
 import { useNotification } from '@/src/context/NotificationContext';
 import { NotificationType } from '@/src/models/notification';
+import { useNavigationLoading } from '@/src/context/NavigationLoadingContext';
+import { useIsomorphicLayoutEffect } from '@/src/utils/useIsomorphicLayoutEffect';
 
 interface Props<T = BaseEntity> {
   menuItem: Menu;
@@ -44,6 +46,11 @@ export function ListContent<T = BaseEntity>({
 }: Props<T>) {
   const router = useRouter();
   const { showNotification } = useNotification();
+  const { setLoading } = useNavigationLoading();
+
+  useIsomorphicLayoutEffect(() => {
+    setLoading(false);
+  }, [setLoading]);
 
   useEffect(() => {
     if (initialError) {

--- a/apps/statgpt-admin-frontend/src/components/LoadingStateSetter/LoadingStateSetter.tsx
+++ b/apps/statgpt-admin-frontend/src/components/LoadingStateSetter/LoadingStateSetter.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useNavigationLoading } from '@/src/context/NavigationLoadingContext';
+import { useIsomorphicLayoutEffect } from '@/src/utils/useIsomorphicLayoutEffect';
+
+export function LoadingStateSetter() {
+  const { setLoading } = useNavigationLoading();
+
+  useIsomorphicLayoutEffect(() => {
+    setLoading(true);
+    return () => setLoading(false);
+  }, [setLoading]);
+
+  return null;
+}

--- a/apps/statgpt-admin-frontend/src/components/MainShell/MainShell.tsx
+++ b/apps/statgpt-admin-frontend/src/components/MainShell/MainShell.tsx
@@ -2,15 +2,18 @@ import { ReactNode } from 'react';
 
 import { Header } from '@/src/components/Header/Header';
 import { MenuSideBar } from '@/src/components/Menu/Menu';
+import { NavigationLoadingProvider } from '@/src/context/NavigationLoadingContext';
 
 export function MainShell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-full flex-col">
-      <Header />
-      <div className="flex flex-row h-full">
-        <MenuSideBar disableMenuItems={process.env.DISABLE_MENU_ITEMS} />
-        <div className="flex-1 min-w-0 p-4">{children}</div>
+    <NavigationLoadingProvider>
+      <div className="flex h-full flex-col">
+        <Header />
+        <div className="flex flex-row h-full">
+          <MenuSideBar disableMenuItems={process.env.DISABLE_MENU_ITEMS} />
+          <div className="flex-1 min-w-0 p-4">{children}</div>
+        </div>
       </div>
-    </div>
+    </NavigationLoadingProvider>
   );
 }

--- a/apps/statgpt-admin-frontend/src/components/Menu/Menu.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Menu/Menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC } from 'react';
 
 import Channels from '@/public/icons/menu/channels.svg';
@@ -5,57 +7,73 @@ import DataSource from '@/public/icons/menu/data-sources.svg';
 import DataSets from '@/public/icons/menu/datasets.svg';
 import Documents from '@/public/icons/menu/documents.svg';
 import { Menu, MenuUrl } from '@/src/constants/menu';
+import { useNavigationLoading } from '@/src/context/NavigationLoadingContext';
 import { MenuItem } from './MenuItem/MenuItem';
+import { MenuItemSkeleton } from './MenuItem/MenuItemSkeleton';
 import { IconLogs } from '@tabler/icons-react';
 
 interface Props {
   disableMenuItems?: string;
 }
+
 export const MenuSideBar: FC<Props> = ({ disableMenuItems }) => {
+  const { isLoading } = useNavigationLoading();
   const disableItems = disableMenuItems
     ? disableMenuItems.split(',').map((item) => item.toLowerCase().trim())
     : [];
 
   return (
     <nav className="flex flex-col p-2 bg-layer-3 w-[260px]">
-      {!disableItems.includes('datasources') && (
-        <MenuItem
-          icon={<DataSource />}
-          title={Menu.DATA_SOURCES}
-          url={MenuUrl.DATA_SOURCES}
-        />
-      )}
+      {isLoading ? (
+        <>
+          <MenuItemSkeleton />
+          <MenuItemSkeleton />
+          <MenuItemSkeleton />
+          <MenuItemSkeleton />
+          <MenuItemSkeleton />
+        </>
+      ) : (
+        <>
+          {!disableItems.includes('datasources') && (
+            <MenuItem
+              icon={<DataSource />}
+              title={Menu.DATA_SOURCES}
+              url={MenuUrl.DATA_SOURCES}
+            />
+          )}
 
-      {!disableItems.includes('datasources') && (
-        <MenuItem
-          icon={<DataSets />}
-          title={Menu.DATA_SETS}
-          url={MenuUrl.DATA_SETS}
-        />
-      )}
+          {!disableItems.includes('datasources') && (
+            <MenuItem
+              icon={<DataSets />}
+              title={Menu.DATA_SETS}
+              url={MenuUrl.DATA_SETS}
+            />
+          )}
 
-      {!disableItems.includes('documents') && (
-        <MenuItem
-          icon={<Documents />}
-          title={Menu.DOCUMENTS}
-          url={MenuUrl.DOCUMENTS}
-        />
-      )}
+          {!disableItems.includes('documents') && (
+            <MenuItem
+              icon={<Documents />}
+              title={Menu.DOCUMENTS}
+              url={MenuUrl.DOCUMENTS}
+            />
+          )}
 
-      {!disableItems.includes('channels') && (
-        <MenuItem
-          icon={<Channels />}
-          title={Menu.CHANNELS}
-          url={MenuUrl.CHANNELS}
-        />
-      )}
+          {!disableItems.includes('channels') && (
+            <MenuItem
+              icon={<Channels />}
+              title={Menu.CHANNELS}
+              url={MenuUrl.CHANNELS}
+            />
+          )}
 
-      {!disableItems.includes('audit-logs') && (
-        <MenuItem
-          icon={<IconLogs className="size-[18px]" />}
-          title={Menu.AUDIT_LOGS}
-          url={MenuUrl.AUDIT_LOGS}
-        />
+          {!disableItems.includes('audit-logs') && (
+            <MenuItem
+              icon={<IconLogs className="size-[18px]" />}
+              title={Menu.AUDIT_LOGS}
+              url={MenuUrl.AUDIT_LOGS}
+            />
+          )}
+        </>
       )}
     </nav>
   );

--- a/apps/statgpt-admin-frontend/src/components/Menu/MenuItem/MenuItemSkeleton.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Menu/MenuItem/MenuItemSkeleton.tsx
@@ -1,0 +1,3 @@
+export function MenuItemSkeleton() {
+  return <div className="h-8 mb-1 rounded bg-layer-4 animate-pulse" />;
+}

--- a/apps/statgpt-admin-frontend/src/components/TermsView/TermsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/TermsView/TermsView.tsx
@@ -14,6 +14,7 @@ import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { EntityOperation } from '@/src/constants/columns/action';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
 import { ChannelTerm } from '@/src/models/channel';
 import { GridOptions } from 'ag-grid-community';
 import { TermsActionColumn } from './ActionColumn/ActionColumn';
@@ -27,7 +28,9 @@ export const TermsView: FC<Props> = ({ selectedChannelId }) => {
   const { setForbidden } = useAccessControl();
   const withNotification = useApiNotification();
   const [isLoading, setIsLoading] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
   const [isAddView, setIsLoadingAddView] = useState(false);
+  usePageInitialLoadingSync(isInitialLoading);
   const [terms, setTerms] = useState<ChannelTerm[]>([]);
   const [editableTerm, setEditableTerm] = useState<ChannelTerm | undefined>(
     void 0,
@@ -135,6 +138,7 @@ export const TermsView: FC<Props> = ({ selectedChannelId }) => {
       }
       setTerms(result.ok ? result.data : []);
       setIsLoading(false);
+      setIsInitialLoading(false);
     });
   }, [selectedChannelId]);
 

--- a/apps/statgpt-admin-frontend/src/context/NavigationLoadingContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/NavigationLoadingContext.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { usePathname } from 'next/navigation';
+
+import { useIsomorphicLayoutEffect } from '@/src/utils/useIsomorphicLayoutEffect';
+
+interface NavigationLoadingContextValue {
+  isLoading: boolean;
+  setLoading: (v: boolean) => void;
+}
+
+const NavigationLoadingContext = createContext<NavigationLoadingContextValue>({
+  isLoading: true,
+  setLoading: () => void 0,
+});
+
+export function useNavigationLoading() {
+  return useContext(NavigationLoadingContext);
+}
+
+export function NavigationLoadingProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [isLoading, setLoading] = useState(true);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setLoading(true);
+  }, [pathname]);
+
+  return (
+    <NavigationLoadingContext.Provider value={{ isLoading, setLoading }}>
+      {children}
+    </NavigationLoadingContext.Provider>
+  );
+}
+
+export function usePageInitialLoadingSync(isLoading: boolean) {
+  const { setLoading } = useContext(NavigationLoadingContext);
+
+  useIsomorphicLayoutEffect(() => {
+    setLoading(isLoading);
+  }, [isLoading, setLoading]);
+}

--- a/apps/statgpt-admin-frontend/src/utils/useIsomorphicLayoutEffect.ts
+++ b/apps/statgpt-admin-frontend/src/utils/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,4 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- #106 

### Description of changes

While a page is fetching its main content, the side menu and header breadcrumb now show animated skeleton placeholders instead of real data, hiding navigation items until the page is fully ready.

A new `NavigationLoadingContext` tracks a global `isLoading` flag. It is set to `true` on navigation start and reset to `false` once page content is ready — via `LoadingStateSetter` in each route’s `loading.tsx` for server-rendered pages, or via the `usePageInitialLoadingSync` hook in client component pages (channel detail views) that manage their own async data fetching.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
