### PR TITLE
fix: minor UX fixes

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/ChannelView/DatasetVersions/DatasetVersions.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/DatasetVersions/DatasetVersions.tsx
@@ -52,6 +52,32 @@ const GRID_COLUMNS = [
     valueFormatter: ({ value }: { value: string | null }) =>
       value ? new Date(value).toLocaleString() : '',
   },
+  {
+    field: 'indexing_stats.harmonization',
+    headerName: 'Harmonization Errors',
+    filter: 'agTextColumnFilter',
+    valueFormatter: ({
+      value,
+    }: {
+      value: NonNullable<
+        ChannelDatasetVersion['indexing_stats']
+      >['harmonization'];
+    }) =>
+      value != null ? `Total: ${value.total}. Errors: ${value.errors}` : '',
+  },
+  {
+    field: 'indexing_stats.normalization',
+    headerName: 'Normalization Errors',
+    filter: 'agTextColumnFilter',
+    valueFormatter: ({
+      value,
+    }: {
+      value: NonNullable<
+        ChannelDatasetVersion['indexing_stats']
+      >['normalization'];
+    }) =>
+      value != null ? `Total: ${value.total}. Errors: ${value.errors}` : '',
+  },
 ];
 
 export const DatasetVersions: FC<Props> = ({ channelId, datasetId }) => {

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/AutoUpdateJobsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/AutoUpdateJobsView.tsx
@@ -92,10 +92,8 @@ export const AutoUpdateJobsView: FC<Props> = ({
 
       if (datasetsResult.ok) {
         const match = datasetsResult.data.data.find(
-          (ds) => String(ds.id) === selectedDatasetId,
-        ) as (typeof datasetsResult.data.data)[number] & {
-          dataset?: { title?: string };
-        };
+          (ds) => String(ds.dataset_id) === selectedDatasetId,
+        );
         if (match?.dataset?.title) {
           setDatasetName(match.dataset.title);
         }

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -137,11 +137,6 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
       filter: 'agTextColumnFilter',
     },
     {
-      field: 'preprocessing_status',
-      headerName: 'Status',
-      filter: 'agTextColumnFilter',
-    },
-    {
       field: 'dataset.status.status',
       headerName: 'Dataset Status',
       filter: 'agTextColumnFilter',

--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
@@ -204,7 +204,7 @@ export const ActionColumn: FC<Props> = ({
             close={() => setIsOpenDeleteModal(false)}
             confirm={() => confirmDelete()}
             title={getDeleteTitle(listView)}
-            description={getDeleteDescription(listView)}
+            description={getDeleteDescription(listView, data)}
           />,
           document.body,
         )}

--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
@@ -174,7 +174,7 @@ export const ActionColumn: FC<Props> = ({
               if (item === EntityOperation.AutoUpdateJobs) {
                 const channelId = pathname.split('/')[2];
                 router.push(
-                  `/channels/${channelId}/datasets/${data.id}/auto-update-jobs`,
+                  `/channels/${channelId}/datasets/${data.dataset_id}/auto-update-jobs`,
                 );
               }
 

--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/utils.ts
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/utils.ts
@@ -63,7 +63,10 @@ export const getDeleteTitle = (item: Menu) => {
   return 'Confirm deleting Channel';
 };
 
-export const getDeleteDescription = (item: Menu) => {
+export const getDeleteDescription = (
+  item: Menu,
+  data?: Record<string, unknown>,
+) => {
   if (item === Menu.DATA_SOURCES) {
     return 'Are you sure that you want to remove Data Source?';
   }
@@ -74,6 +77,12 @@ export const getDeleteDescription = (item: Menu) => {
 
   if (item === Menu.DOCUMENTS) {
     return 'Are you sure that you want to remove Document?';
+  }
+
+  if (item === Menu.CHANNEL_DATASETS) {
+    const datasetName = (data?.dataset as Record<string, unknown> | undefined)
+      ?.title as string | undefined;
+    return `Are you sure that you want to remove ${datasetName ?? 'Dataset'} from this channel?`;
   }
 
   return 'Are you sure that you want to remove Channel?';

--- a/apps/statgpt-admin-frontend/src/models/channel-dataset-version.ts
+++ b/apps/statgpt-admin-frontend/src/models/channel-dataset-version.ts
@@ -15,5 +15,16 @@ export interface ChannelDatasetVersion {
   non_indicator_dimensions_hash: string;
   special_dimensions_hash: string;
   resolved_config: Record<string, unknown>;
-  indexing_stats: Record<string, unknown>;
+  indexing_stats: {
+    harmonization?: {
+      error_types: Record<string, unknown>;
+      errors: number;
+      total: number;
+    };
+    normalization?: {
+      error_types: Record<string, unknown>;
+      errors: number;
+      total: number;
+    };
+  } | null;
 }

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -11,6 +11,7 @@ import {
 } from 'rxjs';
 
 import { Channel, ChannelTerm } from '@/src/models/channel';
+import { ChannelDataset } from '@/src/models/channel-dataset';
 import { ChannelDatasetVersion } from '@/src/models/channel-dataset-version';
 import { DataSet } from '@/src/models/data-sets';
 import { RequestData } from '@/src/models/request-data';
@@ -262,7 +263,7 @@ export class ChannelsApi extends BaseApi {
   getChannelDataset(
     id: string,
     token: JWT | null,
-  ): Promise<ApiResult<RequestData<DataSet>>> {
+  ): Promise<ApiResult<RequestData<ChannelDataset>>> {
     return this.get(`${CHANNEL_DATA_SETS_URL(id)}?limit=500`, token);
   }
 


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/131
- https://github.com/epam/statgpt-admin-frontend/issues/135

### Description of changes

- Use the correct `dataset_id` field when opening the **Auto Update Jobs** page
- Remove the old status field from the **Channel Dataset** grid
- Add columns with indexing errors to the **Dataset Versions** page
- Fix the delete **Channel Dataset** confirmation message

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
