### PR TITLE
feat: add select provider step to the Add dataset modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules
 # IDE - VSCode
 .vscode/*
 
+
 # misc
 /.sass-cache
 /connect.lock

--- a/apps/statgpt-admin-frontend/src/app/data-sources/actions.ts
+++ b/apps/statgpt-admin-frontend/src/app/data-sources/actions.ts
@@ -7,13 +7,22 @@ import { DataSource } from '@/src/models/data-source';
 import { getUserToken } from '@/src/utils/auth/get-token';
 import { getIsEnableAuthToggle } from '@/src/utils/get-auth-toggle';
 
-export async function loadAvailableDataSets(id: number) {
+export async function loadProviders(id: number) {
   const token = await getUserToken(
     getIsEnableAuthToggle(),
     headers(),
     cookies(),
   );
-  return dataSourcesApi.loadAvailableDataSets(id.toString(), token);
+  return dataSourcesApi.getProviders(id.toString(), token);
+}
+
+export async function loadAvailableDataSets(id: number, providerId: string) {
+  const token = await getUserToken(
+    getIsEnableAuthToggle(),
+    headers(),
+    cookies(),
+  );
+  return dataSourcesApi.loadAvailableDataSets(id.toString(), providerId, token);
 }
 
 export async function getDataSources() {

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
@@ -17,6 +17,7 @@ import { Step } from '@/src/models/step';
 import { ModalsButtons } from './Buttons/ModalsButtons';
 import { DataSetStep } from './DataSetStep/DataSetStep';
 import { DataSourceStep } from './DataSourceStep/DataSourceStep';
+import { ProviderStep } from './ProviderStep/ProviderStep';
 
 interface Props {
   close: () => void;
@@ -32,6 +33,10 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       isCompleted: () => !!newDataSet?.data_source_id,
     },
     {
+      key: DatasetStep.Provider,
+      isCompleted: () => !!selectedProviderId,
+    },
+    {
       key: DatasetStep.DataSet,
       isCompleted: () => !!newDataSet?.title,
     },
@@ -41,6 +46,9 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
   const [newDataSet, setDataSet] = useState<DataSet>({
     details: void 0,
   });
+  const [selectedProviderId, setSelectedProviderId] = useState<
+    string | undefined
+  >(undefined);
   const [rawConfig, setRawConfig] = useState('');
   const [nameConfigTouched, setNameConfigTouched] = useState(false);
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
@@ -49,16 +57,14 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
   const [activeStep, setActiveStep] = useState(dataSetSteps[0].key);
 
   useEffect(() => {
-    if (dataSources.length === 0 && !isLoadingData) {
-      setIsLoadingDs(true);
-      withNotification(getDataSources(), 'Failed to Load Data Sources').then(
-        (result) => {
-          setIsLoadingDs(false);
-          if (result.ok) setDataSources(result.data.data);
-        },
-      );
-    }
-  }, [dataSources, isLoadingData]);
+    setIsLoadingDs(true);
+    withNotification(getDataSources(), 'Failed to Load Data Sources').then(
+      (result) => {
+        setIsLoadingDs(false);
+        if (result.ok) setDataSources(result.data.data);
+      },
+    );
+  }, []);
 
   const createDataset = () => {
     if (!newDataSet?.title?.trim()) {
@@ -101,7 +107,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       return (
         <DataSourceStep
           data={dataSources}
-          selectDs={(id) =>
+          selectDataset={(id) =>
             setDataSet({
               ...(newDataSet || {}),
               data_source_id: id,
@@ -111,10 +117,20 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       );
     }
 
+    if (activeStep === DatasetStep.Provider) {
+      return (
+        <ProviderStep
+          selectedDataSourceId={newDataSet?.data_source_id}
+          selectProvider={(id) => setSelectedProviderId(id)}
+        />
+      );
+    }
+
     if (activeStep === DatasetStep.DataSet) {
       return (
         <DataSetStep
           selectedDataSourceId={newDataSet?.data_source_id}
+          selectedProviderId={selectedProviderId}
           changeDataSet={({ title, details }) => {
             setDataSet({ ...(newDataSet || {}), title, details } as DataSet);
             setRawConfig(details ? stringify(details) : '');
@@ -160,6 +176,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
         activeStep={activeStep}
         setActiveStep={setActiveStep}
         isValidDataSourceStep={!newDataSet?.data_source_id}
+        isValidProviderStep={!selectedProviderId}
         isValidDataSetStep={!newDataSet?.details || !newDataSet?.title}
       />
     </Modal>

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/Buttons/ModalsButtons.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/Buttons/ModalsButtons.tsx
@@ -7,6 +7,7 @@ import { BASE_ICON_PROPS } from '@/src/constants/layout';
 
 interface Props {
   isValidDataSourceStep: boolean;
+  isValidProviderStep: boolean;
   isValidDataSetStep: boolean;
   activeStep: string;
   create: () => void;
@@ -17,8 +18,9 @@ interface Props {
 export const ModalsButtons: FC<Props> = ({
   setActiveStep,
   activeStep,
-  isValidDataSetStep,
   isValidDataSourceStep,
+  isValidProviderStep,
+  isValidDataSetStep,
   create,
   close,
 }) => {
@@ -40,11 +42,12 @@ export const ModalsButtons: FC<Props> = ({
           <Button
             cssClass="primary ml-3"
             title="Next"
-            disable={
-              activeStep === DatasetStep.DataSource
-                ? isValidDataSourceStep
-                : isValidDataSetStep
-            }
+            disable={getIsNextDisabled(
+              activeStep,
+              isValidDataSourceStep,
+              isValidProviderStep,
+              isValidDataSetStep,
+            )}
             onClick={() => setActiveStep(getNextStep(activeStep))}
           />
         )}
@@ -62,17 +65,24 @@ export const ModalsButtons: FC<Props> = ({
 };
 
 const getPreviousStep = (activeStep: string) => {
-  if (activeStep === DatasetStep.DataSource) {
-    return DatasetStep.DataSet;
-  }
-
-  return DatasetStep.DataSource;
+  if (activeStep === DatasetStep.Provider) return DatasetStep.DataSource;
+  if (activeStep === DatasetStep.DataSet) return DatasetStep.Provider;
+  return DatasetStep.DataSet;
 };
 
 const getNextStep = (activeStep: string) => {
-  if (activeStep === DatasetStep.DataSource) {
-    return DatasetStep.DataSet;
-  }
-
+  if (activeStep === DatasetStep.DataSource) return DatasetStep.Provider;
+  if (activeStep === DatasetStep.Provider) return DatasetStep.DataSet;
   return BaseStep.Configuration;
+};
+
+const getIsNextDisabled = (
+  activeStep: string,
+  isValidDataSourceStep: boolean,
+  isValidProviderStep: boolean,
+  isValidDataSetStep: boolean,
+) => {
+  if (activeStep === DatasetStep.DataSource) return isValidDataSourceStep;
+  if (activeStep === DatasetStep.Provider) return isValidProviderStep;
+  return isValidDataSetStep;
 };

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
@@ -11,6 +11,7 @@ import { generateShortUrn } from '@/src/utils/urn';
 
 interface Props {
   selectedDataSourceId?: number;
+  selectedProviderId?: string;
   changeDataSet: (dataset: Pick<DataSet, 'title' | 'details'>) => void;
 }
 
@@ -25,6 +26,7 @@ const DATASET_URN_COLUMN: ColDef = {
 
 export const DataSetStep: FC<Props> = ({
   selectedDataSourceId,
+  selectedProviderId,
   changeDataSet,
 }) => {
   const withNotification = useApiNotification();
@@ -42,18 +44,18 @@ export const DataSetStep: FC<Props> = ({
   };
 
   useEffect(() => {
-    if (dataSets.length === 0 && !isLoadingDs && selectedDataSourceId != null) {
-      setIsLoadingDs(true);
+    if (selectedDataSourceId == null || selectedProviderId == null) return;
 
-      withNotification(
-        loadAvailableDataSets(selectedDataSourceId),
-        'Failed to Load Datasets',
-      ).then((result) => {
-        setIsLoadingDs(false);
-        if (result.ok) setDataSets(result.data.data);
-      });
-    }
-  }, [dataSets, selectedDataSourceId, isLoadingDs]);
+    setDataSets([]);
+    setIsLoadingDs(true);
+    withNotification(
+      loadAvailableDataSets(selectedDataSourceId, selectedProviderId),
+      'Failed to Load Datasets',
+    ).then((result) => {
+      setIsLoadingDs(false);
+      if (result.ok) setDataSets(result.data.data);
+    });
+  }, [selectedDataSourceId, selectedProviderId]);
 
   return isLoadingDs ? (
     <div className="flex items-center w-full justify-center h-[633px]">

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSourceStep/DataSourceStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSourceStep/DataSourceStep.tsx
@@ -7,14 +7,14 @@ import { DataSource } from '@/src/models/data-source';
 
 interface Props {
   data: DataSource[];
-  selectDs: (id: number) => void;
+  selectDataset: (id: number) => void;
 }
 
-export const DataSourceStep: FC<Props> = ({ data, selectDs }) => {
+export const DataSourceStep: FC<Props> = ({ data, selectDataset }) => {
   const gridOptions: GridOptions = {
     rowSelection: 'single',
     onRowClicked: (event) => {
-      selectDs(event.data.id);
+      selectDataset(event.data.id);
     },
   };
 

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/ProviderStep/ProviderStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/ProviderStep/ProviderStep.tsx
@@ -1,0 +1,67 @@
+import { ColDef, GridOptions } from 'ag-grid-community';
+import { FC, useEffect, useState } from 'react';
+
+import { loadProviders } from '@/src/app/data-sources/actions';
+import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
+import { GridView } from '@/src/components/GridView/GridView';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { Provider } from '@/src/models/data-source';
+
+interface Props {
+  selectedDataSourceId?: number;
+  selectProvider: (id: string) => void;
+}
+
+const PROVIDER_COLUMNS: ColDef[] = [
+  { field: 'id', headerName: 'ID', filter: 'agTextColumnFilter' },
+  { field: 'name', headerName: 'Name', filter: 'agTextColumnFilter' },
+];
+
+export const ProviderStep: FC<Props> = ({
+  selectedDataSourceId,
+  selectProvider,
+}) => {
+  const withNotification = useApiNotification();
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [isLoadingProviders, setIsLoadingProviders] = useState(false);
+
+  const gridOptions: GridOptions = {
+    rowSelection: 'single',
+    onRowClicked: (event) => {
+      selectProvider(event.data.id);
+    },
+  };
+
+  useEffect(() => {
+    if (selectedDataSourceId == null) return;
+
+    setProviders([]);
+    setIsLoadingProviders(true);
+    withNotification(
+      loadProviders(selectedDataSourceId),
+      'Failed to Load Providers',
+    ).then((result) => {
+      setIsLoadingProviders(false);
+      if (result.ok) setProviders(result.data.data);
+    });
+  }, [selectedDataSourceId]);
+
+  return isLoadingProviders ? (
+    <div className="flex items-center w-full justify-center h-[633px]">
+      <Loader />
+    </div>
+  ) : (
+    <div className="flex flex-col common-paddings border-b border-solid border-b-tertiary">
+      <span className="mb-4 small">Select Provider</span>
+
+      <div className="h-[568px]">
+        <GridView
+          colDefs={PROVIDER_COLUMNS}
+          data={providers}
+          additionalOptions={gridOptions}
+          emptyDataTitle="No Providers"
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/Stepper/StepItem/StepItem.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Stepper/StepItem/StepItem.tsx
@@ -33,11 +33,11 @@ export const StepItem: FC<Props> = ({ step, index, isActive, onClick }) => {
 };
 
 const getCssStepClass = (step: Step, isActive: boolean): string => {
-  if (step.isCompleted != null && step.isCompleted?.()) {
-    return styles.step_completed;
-  }
   if (isActive) {
     return styles.step_active;
+  }
+  if (step.isCompleted != null && step.isCompleted?.()) {
+    return styles.step_completed;
   }
 
   return '';

--- a/apps/statgpt-admin-frontend/src/constants/steps.ts
+++ b/apps/statgpt-admin-frontend/src/constants/steps.ts
@@ -5,5 +5,6 @@ export enum BaseStep {
 
 export enum DatasetStep {
   DataSource = 'Data Source',
+  Provider = 'Provider',
   DataSet = 'Dataset',
 }

--- a/apps/statgpt-admin-frontend/src/models/data-source.ts
+++ b/apps/statgpt-admin-frontend/src/models/data-source.ts
@@ -25,6 +25,11 @@ export interface DataSourceType {
   description: string;
 }
 
+export interface Provider {
+  id: string;
+  name: string;
+}
+
 export interface DataSourceUpdate {
   /** Title */
   title?: string;

--- a/apps/statgpt-admin-frontend/src/server/data-sources-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/data-sources-api.ts
@@ -1,7 +1,7 @@
 import { JWT } from 'next-auth/jwt';
 
 import { DataSet } from '@/src/models/data-sets';
-import { DataSource, DataSourceType } from '@/src/models/data-source';
+import { DataSource, DataSourceType, Provider } from '@/src/models/data-source';
 import { RequestData } from '@/src/models/request-data';
 import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
@@ -12,8 +12,14 @@ export const DATA_SOURCE_TYPE_URL = `${DATA_SOURCE_URL}/types`;
 export const DATA_SOURCE_WITH_ID_URL = (id?: number | string) =>
   `${DATA_SOURCE_URL}/${id}`;
 
-export const LOAD_AVAILABLE_DATA_SET_URL = (id?: number | string) =>
-  `${DATA_SOURCE_WITH_ID_URL(id)}/available-datasets`;
+export const LOAD_PROVIDERS_URL = (id?: number | string) =>
+  `${DATA_SOURCE_WITH_ID_URL(id)}/providers`;
+
+export const LOAD_AVAILABLE_DATA_SET_URL = (
+  id?: number | string,
+  providerId?: string,
+) =>
+  `${DATA_SOURCE_WITH_ID_URL(id)}/available-datasets${providerId ? `?provider=${providerId}` : ''}`;
 
 export class DataSourcesApi extends BaseApi {
   getDataSources(
@@ -46,10 +52,18 @@ export class DataSourcesApi extends BaseApi {
     return this.delete(DATA_SOURCE_WITH_ID_URL(id), token);
   }
 
-  loadAvailableDataSets(
+  getProviders(
     id: string,
     token: JWT | null,
+  ): Promise<ApiResult<RequestData<Provider>>> {
+    return this.get(LOAD_PROVIDERS_URL(id), token);
+  }
+
+  loadAvailableDataSets(
+    id: string,
+    providerId: string,
+    token: JWT | null,
   ): Promise<ApiResult<RequestData<DataSet>>> {
-    return this.get(LOAD_AVAILABLE_DATA_SET_URL(id), token);
+    return this.get(LOAD_AVAILABLE_DATA_SET_URL(id, providerId), token);
   }
 }


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/159
- https://github.com/epam/statgpt-admin-frontend/issues/157

### Description of changes

Add an intermediate Provider selection step between the Data Source and Dataset steps. The selected provider is passed as a query parameter to filter the available datasets list.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
