### PR TITLE
fix: navigation loading skeletons stuck on browser back navigation

### DIFF
--- a/apps/statgpt-admin-frontend/src/context/NavigationLoadingContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/NavigationLoadingContext.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-  createContext,
-  ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import { createContext, ReactNode, useContext, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 
 import { useIsomorphicLayoutEffect } from '@/src/utils/useIsomorphicLayoutEffect';
@@ -32,10 +26,12 @@ export function NavigationLoadingProvider({
 }) {
   const [isLoading, setLoading] = useState(true);
   const pathname = usePathname();
+  const prevPathnameRef = useRef(pathname);
 
-  useEffect(() => {
+  if (prevPathnameRef.current !== pathname) {
+    prevPathnameRef.current = pathname;
     setLoading(true);
-  }, [pathname]);
+  }
 
   return (
     <NavigationLoadingContext.Provider value={{ isLoading, setLoading }}>


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/156

### Description of changes

On browser back navigation, the header/sidebar loading skeletons stayed visible forever instead of resolving to page content.

**Cause**: `NavigationLoadingProvider` flipped `isLoading` to `true` in a `useEffect` on pathname change. Parent `useEffects` run after child `useLayoutEffects`, so on back nav (no Suspense fallback to clear it later) the provider overwrote the page's `setLoading(false)` and nothing reset it.

**Fix**: Detect the `pathname` change during render via a `useRef` and call `setLoading(true)` synchronously, so the new page's layout effect setting false wins.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
