### PR TITLE
fix: show forbidden banner on a documents page

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/(main)/documents/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/(main)/documents/page.tsx
@@ -29,7 +29,7 @@ export default async function Page() {
   const result = await documentsApi.getList(null);
   if (result.ok) {
     data = result.data;
-  } else if (result.error.status === 403) {
+  } else if (result.error.status === 401 || result.error.status === 403) {
     return <ForbiddenTrigger />;
   } else {
     logger.error(`Getting documents error ${result.error.message}`);


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/106

### Description of changes

Show forbidden banner on documents page when DIAL returns 401 (in addition to 403), so users without access see the no-permission message instead of an empty UI.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
