### PR TITLE
feat: show last auto update job status in the channel datasets view

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -14,6 +14,7 @@ import { ACTION_COLUMN, EntityOperation } from '@/src/constants/columns/action';
 import { Menu } from '@/src/constants/menu';
 import { useAccessControl } from '@/src/context/AccessControlContext';
 import { useNotification } from '@/src/context/NotificationContext';
+import { ChannelDataset } from '@/src/models/channel-dataset';
 import { ChannelIndexStatus } from '@/src/models/channel-index-status';
 import { DataSet } from '@/src/models/data-sets';
 import { NotificationType } from '@/src/models/notification';
@@ -180,6 +181,24 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
       field: 'latest_version.preprocessing_status',
       headerName: 'Latest Status',
       filter: 'agTextColumnFilter',
+    },
+    {
+      headerName: 'Last check',
+      valueGetter: ({ data }: { data: ChannelDataset }) => {
+        const job = data.last_auto_update_job;
+        if (!job) return '';
+        const label = job.status !== 'COMPLETED' ? job.status : job.result;
+        const date = job.updated_at
+          ? new Date(job.updated_at).toLocaleString()
+          : '';
+        return [label, date].filter(Boolean).join(' | ');
+      },
+      tooltipValueGetter: ({ data }: { data: ChannelDataset }) => {
+        const job = data.last_auto_update_job;
+        if (!job) return null;
+        return job.details || job.reason_for_failure || null;
+      },
+      tooltipComponent: DETAILS_TOOLTIP_KEY,
     },
     ACTION_COLUMN({
       listView: Menu.CHANNEL_DATASETS,

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -42,6 +42,7 @@ import {
 import ArrowUpIcon from '@/public/icons/arrow-up.svg';
 import { DeduplicationAlert } from './DeduplicationAlert';
 import { DeduplicationStatsModal } from './DeduplicationStatsModal';
+import { ColDef, ITooltipParams, ValueGetterParams } from 'ag-grid-community';
 
 interface Props {
   selectedChannelId?: string;
@@ -132,7 +133,7 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
     });
   };
 
-  const gridColumns = [
+  const gridColumns: ColDef[] = [
     {
       field: 'dataset.title',
       headerName: 'Name',
@@ -184,8 +185,8 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
     },
     {
       headerName: 'Last check',
-      valueGetter: ({ data }: { data: ChannelDataset }) => {
-        const job = data.last_auto_update_job;
+      valueGetter: (params: ValueGetterParams) => {
+        const job = (params.data as ChannelDataset)?.last_auto_update_job;
         if (!job) return '';
         const label = job.status !== 'COMPLETED' ? job.status : job.result;
         const date = job.updated_at
@@ -193,8 +194,8 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
           : '';
         return [label, date].filter(Boolean).join(' | ');
       },
-      tooltipValueGetter: ({ data }: { data: ChannelDataset }) => {
-        const job = data.last_auto_update_job;
+      tooltipValueGetter: (params: ITooltipParams) => {
+        const job = (params.data as ChannelDataset)?.last_auto_update_job;
         if (!job) return null;
         return job.details || job.reason_for_failure || null;
       },

--- a/apps/statgpt-admin-frontend/src/components/GridView/GridView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/GridView.tsx
@@ -213,6 +213,7 @@ function GridViewInner<T = BaseEntity>({
         loadingOverlayComponent="loadingOverlay"
         onGridReady={onGridReady}
         tooltipShowDelay={500}
+        popupParent={document.body}
         defaultColDef={defaultColDef}
         onGridSizeChanged={(e) => e.api.sizeColumnsToFit()}
         rowModelType={isInfinite ? 'infinite' : undefined}

--- a/apps/statgpt-admin-frontend/src/models/channel-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/channel-dataset.ts
@@ -1,3 +1,16 @@
+export interface AutoUpdateJob {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  channel_dataset_id: number;
+  base_version_id: number;
+  created_version_id: number;
+  status: string;
+  result: string;
+  details: string;
+  reason_for_failure: string;
+}
+
 export interface ChannelDataset {
   dataset_id: number;
   preprocessing_status: string;
@@ -6,4 +19,5 @@ export interface ChannelDataset {
     description: string;
     data_source: { title: string };
   };
+  last_auto_update_job?: AutoUpdateJob | null;
 }


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/165

### Description of changes

Add `last_auto_update_job` to the **ChannelDataset** model and surface it as a **"Last check"** column in the Channel Datasets grid. The cell shows status (when not `COMPLETED`) or result (when `COMPLETED`), plus the `updated_at` timestamp. Hovering displays a tooltip with `details` or `reason_for_failure`.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
