### PR TITLE
feat: show selected items in the add dataset modal

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/AddDataSet.tsx
@@ -107,6 +107,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       return (
         <DataSourceStep
           data={dataSources}
+          selectedId={newDataSet?.data_source_id}
           selectDataset={(id) =>
             setDataSet({
               ...(newDataSet || {}),
@@ -121,6 +122,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
       return (
         <ProviderStep
           selectedDataSourceId={newDataSet?.data_source_id}
+          selectedProviderId={selectedProviderId}
           selectProvider={(id) => setSelectedProviderId(id)}
         />
       );
@@ -131,6 +133,7 @@ export const AddDataSetModal: FC<Props> = ({ close }) => {
         <DataSetStep
           selectedDataSourceId={newDataSet?.data_source_id}
           selectedProviderId={selectedProviderId}
+          selectedTitle={newDataSet?.title}
           changeDataSet={({ title, details }) => {
             setDataSet({ ...(newDataSet || {}), title, details } as DataSet);
             setRawConfig(details ? stringify(details) : '');

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
@@ -1,7 +1,12 @@
-import { ColDef, GridOptions } from 'ag-grid-community';
+import { ColDef } from 'ag-grid-community';
 import { FC, useEffect, useState } from 'react';
 
 import { loadAvailableDataSets } from '@/src/app/data-sources/actions';
+import {
+  RADIO_SELECT_COLUMN,
+  SINGLE_SELECT_GRID_CLASS,
+  singleSelectGridOptions,
+} from '@/src/components/AddDataSet/singleSelectGridOptions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { BASE_COLUMNS } from '@/src/constants/columns/common-columns';
@@ -35,29 +40,12 @@ export const DataSetStep: FC<Props> = ({
   const [dataSets, setDataSets] = useState<DataSet[]>([]);
   const [isLoadingDs, setIsLoadingDs] = useState(false);
 
-  const gridOptions: GridOptions = {
-    rowSelection: {
-      mode: 'singleRow',
-      checkboxes: true,
-      enableClickSelection: true,
-    },
-    getRowId: (params) => String(params.data.title),
-    onSelectionChanged: (event) => {
-      const selected = event.api.getSelectedRows()[0];
-      if (selected) {
-        changeDataSet({
-          title: selected.title,
-          details: selected.details,
-        });
-      }
-    },
-    onFirstDataRendered: (event) => {
-      if (!selectedTitle) return;
-      event.api.forEachNode((node) => {
-        if (node.data?.title === selectedTitle) node.setSelected(true);
-      });
-    },
-  };
+  const gridOptions = singleSelectGridOptions<DataSet>({
+    getId: (row) => row.title ?? '',
+    selectedId: selectedTitle,
+    onSelect: (row) =>
+      changeDataSet({ title: row.title, details: row.details }),
+  });
 
   useEffect(() => {
     if (selectedDataSourceId == null || selectedProviderId == null) return;
@@ -81,9 +69,9 @@ export const DataSetStep: FC<Props> = ({
     <div className="flex flex-col common-paddings border-b border-solid border-b-tertiary">
       <span className="mb-4 small">Select Dataset</span>
 
-      <div className="h-[568px]">
+      <div className={`${SINGLE_SELECT_GRID_CLASS} h-[568px]`}>
         <GridView
-          colDefs={[DATASET_URN_COLUMN, ...BASE_COLUMNS]}
+          colDefs={[RADIO_SELECT_COLUMN, DATASET_URN_COLUMN, ...BASE_COLUMNS]}
           data={dataSets}
           additionalOptions={gridOptions}
           emptyDataTitle="No Datasets"

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSetStep/DataSetStep.tsx
@@ -12,6 +12,7 @@ import { generateShortUrn } from '@/src/utils/urn';
 interface Props {
   selectedDataSourceId?: number;
   selectedProviderId?: string;
+  selectedTitle?: string;
   changeDataSet: (dataset: Pick<DataSet, 'title' | 'details'>) => void;
 }
 
@@ -27,6 +28,7 @@ const DATASET_URN_COLUMN: ColDef = {
 export const DataSetStep: FC<Props> = ({
   selectedDataSourceId,
   selectedProviderId,
+  selectedTitle,
   changeDataSet,
 }) => {
   const withNotification = useApiNotification();
@@ -34,11 +36,25 @@ export const DataSetStep: FC<Props> = ({
   const [isLoadingDs, setIsLoadingDs] = useState(false);
 
   const gridOptions: GridOptions = {
-    rowSelection: 'single',
-    onRowSelected: (event) => {
-      changeDataSet({
-        title: event.data.title,
-        details: event.data.details,
+    rowSelection: {
+      mode: 'singleRow',
+      checkboxes: true,
+      enableClickSelection: true,
+    },
+    getRowId: (params) => String(params.data.title),
+    onSelectionChanged: (event) => {
+      const selected = event.api.getSelectedRows()[0];
+      if (selected) {
+        changeDataSet({
+          title: selected.title,
+          details: selected.details,
+        });
+      }
+    },
+    onFirstDataRendered: (event) => {
+      if (!selectedTitle) return;
+      event.api.forEachNode((node) => {
+        if (node.data?.title === selectedTitle) node.setSelected(true);
       });
     },
   };

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSourceStep/DataSourceStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSourceStep/DataSourceStep.tsx
@@ -7,14 +7,31 @@ import { DataSource } from '@/src/models/data-source';
 
 interface Props {
   data: DataSource[];
+  selectedId?: number;
   selectDataset: (id: number) => void;
 }
 
-export const DataSourceStep: FC<Props> = ({ data, selectDataset }) => {
+export const DataSourceStep: FC<Props> = ({
+  data,
+  selectedId,
+  selectDataset,
+}) => {
   const gridOptions: GridOptions = {
-    rowSelection: 'single',
-    onRowClicked: (event) => {
-      selectDataset(event.data.id);
+    rowSelection: {
+      mode: 'singleRow',
+      checkboxes: true,
+      enableClickSelection: true,
+    },
+    getRowId: (params) => String(params.data.id),
+    onSelectionChanged: (event) => {
+      const selected = event.api.getSelectedRows()[0];
+      if (selected) selectDataset(selected.id);
+    },
+    onFirstDataRendered: (event) => {
+      if (selectedId == null) return;
+      event.api.forEachNode((node) => {
+        if (node.data?.id === selectedId) node.setSelected(true);
+      });
     },
   };
 

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSourceStep/DataSourceStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/DataSourceStep/DataSourceStep.tsx
@@ -1,7 +1,11 @@
-import { GridOptions } from 'ag-grid-community';
 import { FC } from 'react';
 
 import { GridView } from '@/src//components/GridView/GridView';
+import {
+  RADIO_SELECT_COLUMN,
+  SINGLE_SELECT_GRID_CLASS,
+  singleSelectGridOptions,
+} from '@/src/components/AddDataSet/singleSelectGridOptions';
 import { DATA_SOURCE_COLUMNS } from '@/src/constants/columns/grid-columns';
 import { DataSource } from '@/src/models/data-source';
 
@@ -16,32 +20,19 @@ export const DataSourceStep: FC<Props> = ({
   selectedId,
   selectDataset,
 }) => {
-  const gridOptions: GridOptions = {
-    rowSelection: {
-      mode: 'singleRow',
-      checkboxes: true,
-      enableClickSelection: true,
-    },
-    getRowId: (params) => String(params.data.id),
-    onSelectionChanged: (event) => {
-      const selected = event.api.getSelectedRows()[0];
-      if (selected) selectDataset(selected.id);
-    },
-    onFirstDataRendered: (event) => {
-      if (selectedId == null) return;
-      event.api.forEachNode((node) => {
-        if (node.data?.id === selectedId) node.setSelected(true);
-      });
-    },
-  };
+  const gridOptions = singleSelectGridOptions<DataSource>({
+    getId: (row) => String(row.id),
+    selectedId: selectedId != null ? String(selectedId) : undefined,
+    onSelect: (row) => row.id != null && selectDataset(row.id),
+  });
 
   return (
     <div className="flex flex-col common-paddings border-b border-solid border-b-tertiary">
       <span className="mb-4 small">Select Data Source</span>
 
-      <div className="h-[568px]">
+      <div className={`${SINGLE_SELECT_GRID_CLASS} h-[568px]`}>
         <GridView
-          colDefs={DATA_SOURCE_COLUMNS}
+          colDefs={[RADIO_SELECT_COLUMN, ...DATA_SOURCE_COLUMNS]}
           data={data}
           additionalOptions={gridOptions}
           emptyDataTitle="No Data Sources"

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/ProviderStep/ProviderStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/ProviderStep/ProviderStep.tsx
@@ -9,6 +9,7 @@ import { Provider } from '@/src/models/data-source';
 
 interface Props {
   selectedDataSourceId?: number;
+  selectedProviderId?: string;
   selectProvider: (id: string) => void;
 }
 
@@ -19,6 +20,7 @@ const PROVIDER_COLUMNS: ColDef[] = [
 
 export const ProviderStep: FC<Props> = ({
   selectedDataSourceId,
+  selectedProviderId,
   selectProvider,
 }) => {
   const withNotification = useApiNotification();
@@ -26,9 +28,21 @@ export const ProviderStep: FC<Props> = ({
   const [isLoadingProviders, setIsLoadingProviders] = useState(false);
 
   const gridOptions: GridOptions = {
-    rowSelection: 'single',
-    onRowClicked: (event) => {
-      selectProvider(event.data.id);
+    rowSelection: {
+      mode: 'singleRow',
+      checkboxes: true,
+      enableClickSelection: true,
+    },
+    getRowId: (params) => String(params.data.id),
+    onSelectionChanged: (event) => {
+      const selected = event.api.getSelectedRows()[0];
+      if (selected) selectProvider(selected.id);
+    },
+    onFirstDataRendered: (event) => {
+      if (selectedProviderId == null) return;
+      event.api.forEachNode((node) => {
+        if (node.data?.id === selectedProviderId) node.setSelected(true);
+      });
     },
   };
 

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/ProviderStep/ProviderStep.tsx
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/ProviderStep/ProviderStep.tsx
@@ -1,7 +1,12 @@
-import { ColDef, GridOptions } from 'ag-grid-community';
+import { ColDef } from 'ag-grid-community';
 import { FC, useEffect, useState } from 'react';
 
 import { loadProviders } from '@/src/app/data-sources/actions';
+import {
+  RADIO_SELECT_COLUMN,
+  SINGLE_SELECT_GRID_CLASS,
+  singleSelectGridOptions,
+} from '@/src/components/AddDataSet/singleSelectGridOptions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
@@ -14,7 +19,7 @@ interface Props {
 }
 
 const PROVIDER_COLUMNS: ColDef[] = [
-  { field: 'id', headerName: 'ID', filter: 'agTextColumnFilter' },
+  { field: 'id', headerName: 'Provider ID', filter: 'agTextColumnFilter' },
   { field: 'name', headerName: 'Name', filter: 'agTextColumnFilter' },
 ];
 
@@ -27,24 +32,11 @@ export const ProviderStep: FC<Props> = ({
   const [providers, setProviders] = useState<Provider[]>([]);
   const [isLoadingProviders, setIsLoadingProviders] = useState(false);
 
-  const gridOptions: GridOptions = {
-    rowSelection: {
-      mode: 'singleRow',
-      checkboxes: true,
-      enableClickSelection: true,
-    },
-    getRowId: (params) => String(params.data.id),
-    onSelectionChanged: (event) => {
-      const selected = event.api.getSelectedRows()[0];
-      if (selected) selectProvider(selected.id);
-    },
-    onFirstDataRendered: (event) => {
-      if (selectedProviderId == null) return;
-      event.api.forEachNode((node) => {
-        if (node.data?.id === selectedProviderId) node.setSelected(true);
-      });
-    },
-  };
+  const gridOptions = singleSelectGridOptions<Provider>({
+    getId: (row) => row.id,
+    selectedId: selectedProviderId,
+    onSelect: (row) => selectProvider(row.id),
+  });
 
   useEffect(() => {
     if (selectedDataSourceId == null) return;
@@ -68,9 +60,9 @@ export const ProviderStep: FC<Props> = ({
     <div className="flex flex-col common-paddings border-b border-solid border-b-tertiary">
       <span className="mb-4 small">Select Provider</span>
 
-      <div className="h-[568px]">
+      <div className={`${SINGLE_SELECT_GRID_CLASS} h-[568px]`}>
         <GridView
-          colDefs={PROVIDER_COLUMNS}
+          colDefs={[RADIO_SELECT_COLUMN, ...PROVIDER_COLUMNS]}
           data={providers}
           additionalOptions={gridOptions}
           emptyDataTitle="No Providers"

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/singleSelectGrid.module.scss
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/singleSelectGrid.module.scss
@@ -1,0 +1,7 @@
+.singleSelectGrid {
+  :global(.ag-row.ag-row-selected),
+  :global(.ag-row.ag-row-selected.ag-row-hover) {
+    background-color: var(--bg-accent-primary-alpha, #5c8dea2b) !important;
+    box-shadow: inset 0 0 0 1px var(--stroke-accent-primary, #5c8dea) !important;
+  }
+}

--- a/apps/statgpt-admin-frontend/src/components/AddDataSet/singleSelectGridOptions.ts
+++ b/apps/statgpt-admin-frontend/src/components/AddDataSet/singleSelectGridOptions.ts
@@ -1,0 +1,59 @@
+import { ColDef, GridOptions } from 'ag-grid-community';
+
+import { RadioSelectionCellRenderer } from '@/src/components/GridView/RadioSelectionCellRenderer/RadioSelectionCellRenderer';
+
+import styles from './singleSelectGrid.module.scss';
+
+export const SINGLE_SELECT_GRID_CLASS = styles.singleSelectGrid;
+
+interface SingleSelectGridOptionsArgs<T> {
+  getId: (row: T) => string;
+  selectedId?: string;
+  onSelect: (row: T) => void;
+}
+
+export const RADIO_SELECT_COLUMN: ColDef = {
+  width: 36,
+  minWidth: 36,
+  maxWidth: 36,
+  resizable: false,
+  sortable: false,
+  filter: false,
+  floatingFilter: false,
+  suppressMovable: true,
+  suppressHeaderMenuButton: true,
+  pinned: 'left',
+  headerName: '',
+  cellRenderer: RadioSelectionCellRenderer,
+  cellStyle: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+  },
+};
+
+export const singleSelectGridOptions = <T>({
+  getId,
+  selectedId,
+  onSelect,
+}: SingleSelectGridOptionsArgs<T>): GridOptions<T> => ({
+  rowSelection: {
+    mode: 'singleRow',
+    checkboxes: false,
+    enableClickSelection: true,
+  },
+  getRowId: (params) => getId(params.data),
+  onSelectionChanged: (event) => {
+    const selected = event.api.getSelectedRows()[0];
+    if (selected) onSelect(selected);
+  },
+  onFirstDataRendered: (event) => {
+    if (selectedId == null) return;
+    event.api.forEachNode((node) => {
+      if (node.data && getId(node.data) === selectedId) {
+        node.setSelected(true);
+      }
+    });
+  },
+});

--- a/apps/statgpt-admin-frontend/src/components/GridView/RadioSelectionCellRenderer/RadioSelectionCellRenderer.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/RadioSelectionCellRenderer/RadioSelectionCellRenderer.tsx
@@ -1,0 +1,50 @@
+import { ICellRendererParams } from 'ag-grid-community';
+import { FC, useEffect, useState } from 'react';
+
+import { mergeClasses } from '@/src/utils/mergeClasses';
+
+/**
+ * AG Grid cell renderer that displays a single-select radio button reflecting
+ * the row's selection state. Designed to be used as the `cellRenderer` of a
+ * dedicated selection column when AG Grid's built-in checkbox column is
+ * disabled (`rowSelection.checkboxes: false`).
+ *
+ * Clicking the radio selects the row via `node.setSelected(true)`. Row-level
+ * selection events keep the radio in sync, so clicking elsewhere on the row
+ * (when `enableClickSelection: true`) also updates the visual.
+ */
+export const RadioSelectionCellRenderer: FC<ICellRendererParams> = (params) => {
+  const [selected, setSelected] = useState<boolean>(
+    params.node.isSelected() ?? false,
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      setSelected(params.node.isSelected() ?? false);
+    };
+    params.api.addEventListener('selectionChanged', handler);
+    return () => {
+      params.api.removeEventListener('selectionChanged', handler);
+    };
+  }, [params.api, params.node]);
+
+  return (
+    <button
+      type="button"
+      aria-checked={selected}
+      role="radio"
+      className={mergeClasses(
+        'flex items-center justify-center w-[18px] h-[18px] p-0 m-0 rounded-full border-2 bg-transparent cursor-pointer',
+        selected ? 'border-accent-primary' : 'border-hover',
+      )}
+      onClick={(e) => {
+        e.stopPropagation();
+        params.node.setSelected(true);
+      }}
+    >
+      {selected && (
+        <span className="w-2.5 h-2.5 rounded-full bg-accent-primary" />
+      )}
+    </button>
+  );
+};


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/167

### Description of changes

**Add row selection to Add Dataset modal tables.**

The three picker grids in the **Add Dataset** modal (`Data Source, Provider, Dataset`) didn't show the user's previous selection when navigating back through the stepper — the selected row was only kept in React state. This change makes that selection visible.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
