### PR TITLE
fix: show entity names in the breadcrumbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 out
 
 # local env files
+.env
 .env*.local
 
 

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/auto-update-jobs/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/auto-update-jobs/page.tsx
@@ -1,15 +1,30 @@
 'use client';
 
-import { AutoUpdateJobsView } from '@/src/components/ChannelView/Datasets/AutoUpdateJobsView';
 import { useParams } from 'next/navigation';
+
+import { AutoUpdateJobsView } from '@/src/components/ChannelView/Datasets/AutoUpdateJobsView';
+import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
+import { useChannelData } from '@/src/context/ChannelDataContext';
+import { useDatasetData } from '@/src/context/DatasetDataContext';
 
 export default function Page() {
   const params = useParams();
+  const channelId = params.id as string;
+  const datasetId = params.datasetId as string;
+  const { channel } = useChannelData();
+  const { dataset } = useDatasetData();
+
+  useSetBreadcrumbs([
+    { name: 'Channels', href: '/channels' },
+    { name: channel?.title ?? channelId, href: `/channels/${channelId}` },
+    { name: dataset?.dataset.title ?? datasetId },
+    { name: 'Auto Update Jobs' },
+  ]);
 
   return (
     <AutoUpdateJobsView
-      selectedChannelId={params.id as string}
-      selectedDatasetId={params.datasetId as string}
+      selectedChannelId={channelId}
+      selectedDatasetId={datasetId}
     />
   );
 }

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/auto-update-jobs/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/auto-update-jobs/page.tsx
@@ -6,6 +6,8 @@ import { AutoUpdateJobsView } from '@/src/components/ChannelView/Datasets/AutoUp
 import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useChannelData } from '@/src/context/ChannelDataContext';
 import { useDatasetData } from '@/src/context/DatasetDataContext';
+import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 
 export default function Page() {
   const params = useParams();
@@ -15,8 +17,8 @@ export default function Page() {
   const { dataset } = useDatasetData();
 
   useSetBreadcrumbs([
-    { name: 'Channels', href: '/channels' },
-    { name: channel?.title ?? channelId, href: `/channels/${channelId}` },
+    { name: Menu.CHANNELS, href: ROUTES.channels },
+    { name: channel?.title ?? channelId, href: ROUTES.channel(channelId) },
     { name: dataset?.dataset.title ?? datasetId },
     { name: 'Auto Update Jobs' },
   ]);

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/layout.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/layout.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+import { DatasetDataProvider } from '@/src/context/DatasetDataContext';
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ id: string; datasetId: string }>;
+}) {
+  const { id, datasetId } = await params;
+  return (
+    <DatasetDataProvider channelId={id} datasetId={datasetId}>
+      {children}
+    </DatasetDataProvider>
+  );
+}

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/versions/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/versions/page.tsx
@@ -6,6 +6,8 @@ import { DatasetVersions } from '@/src/components/ChannelView/DatasetVersions/Da
 import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useChannelData } from '@/src/context/ChannelDataContext';
 import { useDatasetData } from '@/src/context/DatasetDataContext';
+import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,11 +19,11 @@ export default function Page() {
   const { dataset } = useDatasetData();
 
   useSetBreadcrumbs([
-    { name: 'Channels', href: '/channels' },
-    { name: channel?.title ?? channelId, href: `/channels/${channelId}` },
+    { name: Menu.CHANNELS, href: ROUTES.channels },
+    { name: channel?.title ?? channelId, href: ROUTES.channel(channelId) },
     {
       name: dataset?.dataset.title ?? datasetId,
-      href: `/channels/${channelId}/datasets/${datasetId}/versions`,
+      href: ROUTES.datasetVersions(channelId, datasetId),
     },
     { name: 'Versions' },
   ]);

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/versions/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/datasets/[datasetId]/versions/page.tsx
@@ -3,16 +3,28 @@
 import { useParams } from 'next/navigation';
 
 import { DatasetVersions } from '@/src/components/ChannelView/DatasetVersions/DatasetVersions';
+import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
+import { useChannelData } from '@/src/context/ChannelDataContext';
+import { useDatasetData } from '@/src/context/DatasetDataContext';
 
 export const dynamic = 'force-dynamic';
 
 export default function Page() {
   const params = useParams();
+  const channelId = params.id as string;
+  const datasetId = params.datasetId as string;
+  const { channel } = useChannelData();
+  const { dataset } = useDatasetData();
 
-  return (
-    <DatasetVersions
-      channelId={params.id as string}
-      datasetId={params.datasetId as string}
-    />
-  );
+  useSetBreadcrumbs([
+    { name: 'Channels', href: '/channels' },
+    { name: channel?.title ?? channelId, href: `/channels/${channelId}` },
+    {
+      name: dataset?.dataset.title ?? datasetId,
+      href: `/channels/${channelId}/datasets/${datasetId}/versions`,
+    },
+    { name: 'Versions' },
+  ]);
+
+  return <DatasetVersions channelId={channelId} datasetId={datasetId} />;
 }

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/glossary/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/glossary/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from 'next/navigation';
 import { TermsView } from '@/src/components/TermsView/TermsView';
 import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useChannelData } from '@/src/context/ChannelDataContext';
+import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 
 export default function Page() {
   const params = useParams();
@@ -12,8 +14,8 @@ export default function Page() {
   const { channel } = useChannelData();
 
   useSetBreadcrumbs([
-    { name: 'Channels', href: '/channels' },
-    { name: channel?.title ?? id, href: `/channels/${id}` },
+    { name: Menu.CHANNELS, href: ROUTES.channels },
+    { name: channel?.title ?? id, href: ROUTES.channel(id) },
     { name: 'Terms' },
   ]);
 

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/glossary/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/glossary/page.tsx
@@ -1,9 +1,21 @@
 'use client';
-import { TermsView } from '@/src/components/TermsView/TermsView';
+
 import { useParams } from 'next/navigation';
+
+import { TermsView } from '@/src/components/TermsView/TermsView';
+import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
+import { useChannelData } from '@/src/context/ChannelDataContext';
 
 export default function Page() {
   const params = useParams();
+  const id = params.id as string;
+  const { channel } = useChannelData();
 
-  return <TermsView selectedChannelId={params.id as string} />;
+  useSetBreadcrumbs([
+    { name: 'Channels', href: '/channels' },
+    { name: channel?.title ?? id, href: `/channels/${id}` },
+    { name: 'Terms' },
+  ]);
+
+  return <TermsView selectedChannelId={id} />;
 }

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/jobs/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/jobs/page.tsx
@@ -1,9 +1,21 @@
 'use client';
-import { JobsView } from '@/src/components/JobsView/JobsView';
+
 import { useParams } from 'next/navigation';
+
+import { JobsView } from '@/src/components/JobsView/JobsView';
+import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
+import { useChannelData } from '@/src/context/ChannelDataContext';
 
 export default function Page() {
   const params = useParams();
+  const id = params.id as string;
+  const { channel } = useChannelData();
 
-  return <JobsView selectedChannelId={params.id as string} />;
+  useSetBreadcrumbs([
+    { name: 'Channels', href: '/channels' },
+    { name: channel?.title ?? id, href: `/channels/${id}` },
+    { name: 'Jobs' },
+  ]);
+
+  return <JobsView selectedChannelId={id} />;
 }

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/jobs/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/jobs/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from 'next/navigation';
 import { JobsView } from '@/src/components/JobsView/JobsView';
 import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useChannelData } from '@/src/context/ChannelDataContext';
+import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 
 export default function Page() {
   const params = useParams();
@@ -12,8 +14,8 @@ export default function Page() {
   const { channel } = useChannelData();
 
   useSetBreadcrumbs([
-    { name: 'Channels', href: '/channels' },
-    { name: channel?.title ?? id, href: `/channels/${id}` },
+    { name: Menu.CHANNELS, href: ROUTES.channels },
+    { name: channel?.title ?? id, href: ROUTES.channel(id) },
     { name: 'Jobs' },
   ]);
 

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/layout.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/layout.tsx
@@ -1,7 +1,19 @@
 import { ReactNode } from 'react';
 
 import { MainShell } from '@/src/components/MainShell/MainShell';
+import { ChannelDataProvider } from '@/src/context/ChannelDataContext';
 
-export default function Layout({ children }: { children: ReactNode }) {
-  return <MainShell>{children}</MainShell>;
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <MainShell>
+      <ChannelDataProvider channelId={id}>{children}</ChannelDataProvider>
+    </MainShell>
+  );
 }

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from 'next/navigation';
 import { ChannelView } from '@/src/components/ChannelView/ChannelView';
 import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useChannelData } from '@/src/context/ChannelDataContext';
+import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 
 export default function Page() {
   const params = useParams();
@@ -12,7 +14,7 @@ export default function Page() {
   const { channel } = useChannelData();
 
   useSetBreadcrumbs([
-    { name: 'Channels', href: '/channels' },
+    { name: Menu.CHANNELS, href: ROUTES.channels },
     { name: channel?.title ?? id },
   ]);
 

--- a/apps/statgpt-admin-frontend/src/app/channels/[id]/page.tsx
+++ b/apps/statgpt-admin-frontend/src/app/channels/[id]/page.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import { ChannelView } from '@/src/components/ChannelView/ChannelView';
 import { useParams } from 'next/navigation';
+
+import { ChannelView } from '@/src/components/ChannelView/ChannelView';
+import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
+import { useChannelData } from '@/src/context/ChannelDataContext';
 
 export default function Page() {
   const params = useParams();
+  const id = params.id as string;
+  const { channel } = useChannelData();
 
-  return <ChannelView selectedChannelId={params.id as string} />;
+  useSetBreadcrumbs([
+    { name: 'Channels', href: '/channels' },
+    { name: channel?.title ?? id },
+  ]);
+
+  return <ChannelView selectedChannelId={id} />;
 }

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/ChannelView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/ChannelView.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 
-import { useAccessControl } from '@/src/context/AccessControlContext';
-import { getChannel } from '@/src/app/channels/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
-import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useChannelData } from '@/src/context/ChannelDataContext';
 import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
-import { Channel } from '@/src/models/channel';
 import { DataSetsView } from './Datasets/Datasets';
 
 interface Props {
@@ -15,40 +12,16 @@ interface Props {
 }
 
 export const ChannelView: FC<Props> = ({ selectedChannelId }) => {
-  const { setForbidden } = useAccessControl();
-  const withNotification = useApiNotification();
-  const [selectedChannel, setSelectedChannel] = useState<Channel | undefined>(
-    void 0,
-  );
+  const { channel, isLoading } = useChannelData();
+  usePageInitialLoadingSync(isLoading);
 
-  const [isLoadingChannel, setIsLoadingChannel] = useState(true);
-  usePageInitialLoadingSync(isLoadingChannel);
-
-  useEffect(() => {
-    if (selectedChannel == null) {
-      withNotification(
-        getChannel(selectedChannelId),
-        'Failed to Load Channel',
-        [403],
-      ).then((result) => {
-        if (!result.ok && result.error.status === 403) {
-          setIsLoadingChannel(false);
-          setForbidden();
-          return;
-        }
-        setIsLoadingChannel(false);
-        if (result.ok) setSelectedChannel(result.data);
-      });
-    }
-  }, [selectedChannelId]);
-
-  return isLoadingChannel ? (
+  return isLoading ? (
     <div className="flex items-center h-full w-full justify-center bg-layer-2">
       <Loader />
     </div>
   ) : (
     <div className="bg-layer-2 flex flex-col h-full common-paddings">
-      <h1 className="mb-4">{selectedChannel?.title}</h1>
+      <h1 className="mb-4">{channel?.title}</h1>
       <div className="flex-1 min-h-0">
         <DataSetsView selectedChannelId={selectedChannelId} />
       </div>

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/DatasetVersions/DatasetVersions.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/DatasetVersions/DatasetVersions.tsx
@@ -5,16 +5,13 @@ import { FC, useEffect, useState } from 'react';
 import { GridView } from '@/src/components/GridView/GridView';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { useAccessControl } from '@/src/context/AccessControlContext';
+import { useDatasetData } from '@/src/context/DatasetDataContext';
 import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
 import { ChannelDatasetVersion } from '@/src/models/channel-dataset-version';
 import { RequestData } from '@/src/models/request-data';
 import { sendGetRequest } from '@/src/server/api';
-import {
-  CHANNEL_DATA_SETS_URL,
-  CHANNEL_DATASET_VERSIONS_URL,
-} from '@/src/server/channels-api';
+import { CHANNEL_DATASET_VERSIONS_URL } from '@/src/server/channels-api';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
-import { ChannelDataset } from '@/src/models/channel-dataset';
 
 interface Props {
   channelId: string;
@@ -83,26 +80,11 @@ const GRID_COLUMNS = [
 export const DatasetVersions: FC<Props> = ({ channelId, datasetId }) => {
   const withNotification = useApiNotification();
   const { setForbidden } = useAccessControl();
+  const { dataset } = useDatasetData();
 
   const [versions, setVersions] = useState<ChannelDatasetVersion[]>([]);
-  const [datasetTitle, setDatasetTitle] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   usePageInitialLoadingSync(isLoading);
-
-  useEffect(() => {
-    if (!channelId || !datasetId) return;
-
-    sendGetRequest<RequestData<ChannelDataset>>(
-      CHANNEL_DATA_SETS_URL(channelId),
-    ).then((result) => {
-      if (result.ok) {
-        const match = result.data.data.find(
-          (ds) => String(ds.dataset_id) === datasetId,
-        );
-        if (match) setDatasetTitle(match.dataset.title);
-      }
-    });
-  }, [channelId, datasetId]);
 
   useEffect(() => {
     if (!channelId || !datasetId) return;
@@ -124,7 +106,9 @@ export const DatasetVersions: FC<Props> = ({ channelId, datasetId }) => {
         setVersions(result.data.data);
       }
     });
-  }, [channelId, datasetId]);
+  }, [channelId, datasetId, setForbidden, withNotification]);
+
+  const datasetTitle = dataset?.dataset.title;
 
   return isLoading ? (
     <div className="flex items-center w-full justify-center h-full">

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/AutoUpdateJobsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/AutoUpdateJobsView.tsx
@@ -2,14 +2,12 @@
 
 import { FC, useEffect, useState } from 'react';
 
-import {
-  getChannelDatasetAutoUpdateJobs,
-  getChannelDatasets,
-} from '@/src/app/channels/actions';
+import { getChannelDatasetAutoUpdateJobs } from '@/src/app/channels/actions';
 import { Loader } from '@/src/components/BaseComponents/Loader/Loader';
 import { GridView } from '@/src/components/GridView/GridView';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { useAccessControl } from '@/src/context/AccessControlContext';
+import { useDatasetData } from '@/src/context/DatasetDataContext';
 import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
 import { AutoUpdateJob } from '@/src/models/auto-update-job';
 import { DETAILS_TOOLTIP_KEY } from '@/src/components/GridView/DetailsTooltip/DetailsTooltip';
@@ -25,11 +23,13 @@ export const AutoUpdateJobsView: FC<Props> = ({
   selectedDatasetId,
 }) => {
   const { setForbidden } = useAccessControl();
+  const { dataset } = useDatasetData();
   const withNotification = useApiNotification();
   const [isLoading, setIsLoading] = useState(true);
   usePageInitialLoadingSync(isLoading);
   const [jobs, setJobs] = useState<AutoUpdateJob[]>([]);
-  const [datasetName, setDatasetName] = useState<string>('');
+
+  const datasetName = dataset?.dataset.title ?? '';
 
   const columns: ColDef[] = [
     {
@@ -76,32 +76,19 @@ export const AutoUpdateJobsView: FC<Props> = ({
   useEffect(() => {
     setIsLoading(true);
 
-    Promise.all([
-      withNotification(
-        getChannelDatasetAutoUpdateJobs(selectedChannelId, selectedDatasetId),
-        'Failed to Load Auto Update Jobs',
-        [403],
-      ),
-      getChannelDatasets(selectedChannelId),
-    ]).then(([jobsResult, datasetsResult]) => {
-      if (!jobsResult.ok && jobsResult.error.status === 403) {
-        setForbidden();
+    withNotification(
+      getChannelDatasetAutoUpdateJobs(selectedChannelId, selectedDatasetId),
+      'Failed to Load Auto Update Jobs',
+      [403],
+    ).then((jobsResult) => {
+      setIsLoading(false);
+      if (!jobsResult.ok) {
+        if (jobsResult.error.status === 403) setForbidden();
         return;
       }
-      setJobs(jobsResult.ok ? jobsResult.data : []);
-
-      if (datasetsResult.ok) {
-        const match = datasetsResult.data.data.find(
-          (ds) => String(ds.dataset_id) === selectedDatasetId,
-        );
-        if (match?.dataset?.title) {
-          setDatasetName(match.dataset.title);
-        }
-      }
-
-      setIsLoading(false);
+      setJobs(jobsResult.data);
     });
-  }, [selectedChannelId, selectedDatasetId]);
+  }, [selectedChannelId, selectedDatasetId, setForbidden, withNotification]);
 
   return isLoading ? (
     <div className="flex items-center w-full justify-center h-full">

--- a/apps/statgpt-admin-frontend/src/components/EditDataEntity/DataSetChannelResults.tsx
+++ b/apps/statgpt-admin-frontend/src/components/EditDataEntity/DataSetChannelResults.tsx
@@ -5,6 +5,7 @@ import { ColDef, ICellRendererParams, ITooltipParams } from 'ag-grid-community';
 import { IconExternalLink } from '@tabler/icons-react';
 
 import { ChannelResult, ChannelResultStatus } from '@/src/models/data-sets';
+import { ROUTES } from '@/src/constants/routes';
 import { AlertBanner } from '@/src/components/BaseComponents/AlertBanner/AlertBanner';
 import { GridView } from '@/src/components/GridView/GridView';
 import { mergeClasses } from '@/src/utils/mergeClasses';
@@ -25,7 +26,7 @@ const ChannelNameCell = ({ data }: ICellRendererParams<ChannelResult>) => {
     <div className="flex items-center gap-2">
       <span>{data.channel.title}</span>
       <a
-        href={`/channels/${data.channel.id}`}
+        href={ROUTES.channel(data.channel.id)}
         target="_blank"
         rel="noopener noreferrer"
         className="text-accent-primary flex items-center"

--- a/apps/statgpt-admin-frontend/src/components/Header/Header.tsx
+++ b/apps/statgpt-admin-frontend/src/components/Header/Header.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import CollapseMenuIcon from '@/public/icons/menu/collapse-menu.svg';
 import ExpandMenuIcon from '@/public/icons/menu/expand-menu.svg';
-import { MENU_MAP, MenuUrl } from '@/src/constants/menu';
 import { Breadcrumb } from '@/src/models/breadcrumbs';
 import { Breadcrumbs } from '@/src/components/Breadcrumbs/Breadcrumbs';
 import { UserMenu } from '@/src/components/Header/User/UserMenu';
+import { useBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useNavigationLoading } from '@/src/context/NavigationLoadingContext';
 import { useSidebar } from '@/src/context/SidebarContext';
 
@@ -15,48 +16,19 @@ interface HeaderProps {
 }
 
 export const Header = ({ showBreadcrumbs = true }: HeaderProps) => {
-  const pathname = usePathname() as MenuUrl;
   const router = useRouter();
   const { isLoading } = useNavigationLoading();
   const { isCollapsed, toggle } = useSidebar();
+  const entries = useBreadcrumbs();
 
-  const segments = pathname.split('/').filter(Boolean);
-  const [root, channelId, sub, datasetId, leaf] = segments;
-
-  const url = `/${root}` as MenuUrl;
-  const breadcrumbs: Breadcrumb[] = [
-    {
-      name: MENU_MAP[url],
-      click: () => {
-        router.replace(url);
-      },
-    },
-  ];
-
-  if (channelId != null && channelId !== '') {
-    breadcrumbs.push({
-      name: channelId,
-      click: () => router.push(`/channels/${channelId}`),
-    });
-  }
-
-  if (sub === 'glossary') {
-    breadcrumbs.push({ name: 'Terms' });
-  } else if (sub === 'jobs') {
-    breadcrumbs.push({ name: 'Jobs' });
-  } else if (sub === 'datasets' && datasetId != null) {
-    if (leaf === 'versions') {
-      breadcrumbs.push({
-        name: datasetId,
-        click: () =>
-          router.push(`/channels/${channelId}/datasets/${datasetId}/versions`),
-      });
-      breadcrumbs.push({ name: 'Versions' });
-    } else if (leaf === 'auto-update-jobs') {
-      breadcrumbs.push({ name: datasetId });
-      breadcrumbs.push({ name: 'Auto Update Jobs' });
-    }
-  }
+  const breadcrumbs: Breadcrumb[] = useMemo(
+    () =>
+      entries.map((entry) => ({
+        name: entry.name,
+        click: entry.href ? () => router.push(entry.href!) : undefined,
+      })),
+    [entries, router],
+  );
 
   return (
     <header className="h-[48px] flex items-center bg-layer-3 w-full justify-between border-b border-solid border-b-tertiary">

--- a/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ActionColumn/ActionColumn.tsx
@@ -17,6 +17,7 @@ import { ActionItem } from '@/src/components/GridView/ActionColumn/ActionItem';
 import { EntityOperation } from '@/src/constants/columns/action';
 import { BASE_ICON_PROPS } from '@/src/constants/layout';
 import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 import { BaseEntityWithDetails } from '@/src/models/base-entity';
 import { ChannelResult, DataSetUpdateResponse } from '@/src/models/data-sets';
 import { sendDeleteRequest, sendPostRequest } from '@/src/server/api';
@@ -184,25 +185,23 @@ export const ActionColumn: FC<Props> = ({
               }
 
               if (item === EntityOperation.Terms) {
-                router.push(`/channels/${data.id}/glossary`);
+                router.push(ROUTES.channelGlossary(data.id));
               }
 
               if (item === EntityOperation.Jobs) {
-                router.push(`/channels/${data.id}/jobs`);
+                router.push(ROUTES.channelJobs(data.id));
               }
 
               if (item === EntityOperation.AutoUpdateJobs) {
                 const channelId = pathname.split('/')[2];
                 router.push(
-                  `/channels/${channelId}/datasets/${data.dataset_id}/auto-update-jobs`,
+                  ROUTES.datasetAutoUpdateJobs(channelId, data.dataset_id),
                 );
               }
 
               if (item === EntityOperation.Versions) {
                 const channelId = pathname.split('/')[2];
-                router.push(
-                  `/channels/${channelId}/datasets/${data.dataset_id}/versions`,
-                );
+                router.push(ROUTES.datasetVersions(channelId, data.dataset_id));
               }
             }}
           />

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
@@ -4,7 +4,8 @@ import { ColDef, GridOptions } from 'ag-grid-community';
 import { useRouter } from 'next/navigation';
 import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 
-import { Menu, MenuUrl } from '@/src/constants/menu';
+import { Menu } from '@/src/constants/menu';
+import { ROUTES } from '@/src/constants/routes';
 import { BaseEntity } from '@/src/models/base-entity';
 import {
   GridView,
@@ -89,7 +90,7 @@ export function ListContent<T = BaseEntity>({
       }
 
       if (event.data?.id && menuItem === Menu.CHANNELS) {
-        router.push(`${MenuUrl.CHANNELS}/${event.data.id}`);
+        router.push(ROUTES.channel(event.data.id));
       }
     },
     [menuItem, router],

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListContent/ListContent.tsx
@@ -16,6 +16,7 @@ import { ListHeader } from '../ListHeader/ListHeader';
 import { useNotification } from '@/src/context/NotificationContext';
 import { NotificationType } from '@/src/models/notification';
 import { useNavigationLoading } from '@/src/context/NavigationLoadingContext';
+import { useSetBreadcrumbs } from '@/src/context/BreadcrumbContext';
 import { useIsomorphicLayoutEffect } from '@/src/utils/useIsomorphicLayoutEffect';
 
 interface Props<T = BaseEntity> {
@@ -50,6 +51,8 @@ export function ListContent<T = BaseEntity>({
   const { setLoading } = useNavigationLoading();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const pendingRefreshRef = useRef(false);
+
+  useSetBreadcrumbs([{ name: menuItem }]);
 
   const handleConfigureSaved = useCallback(() => {
     pendingRefreshRef.current = true;

--- a/apps/statgpt-admin-frontend/src/components/MainShell/MainShell.tsx
+++ b/apps/statgpt-admin-frontend/src/components/MainShell/MainShell.tsx
@@ -2,18 +2,21 @@ import { ReactNode } from 'react';
 
 import { Header } from '@/src/components/Header/Header';
 import { MenuSideBar } from '@/src/components/Menu/Menu';
+import { BreadcrumbProvider } from '@/src/context/BreadcrumbContext';
 import { NavigationLoadingProvider } from '@/src/context/NavigationLoadingContext';
 
 export function MainShell({ children }: { children: ReactNode }) {
   return (
     <NavigationLoadingProvider>
-      <div className="flex h-full flex-col">
-        <Header />
-        <div className="flex flex-row h-full">
-          <MenuSideBar disableMenuItems={process.env.DISABLE_MENU_ITEMS} />
-          <div className="flex-1 min-w-0 p-4">{children}</div>
+      <BreadcrumbProvider>
+        <div className="flex h-full flex-col">
+          <Header />
+          <div className="flex flex-row h-full">
+            <MenuSideBar disableMenuItems={process.env.DISABLE_MENU_ITEMS} />
+            <div className="flex-1 min-w-0 p-4">{children}</div>
+          </div>
         </div>
-      </div>
+      </BreadcrumbProvider>
     </NavigationLoadingProvider>
   );
 }

--- a/apps/statgpt-admin-frontend/src/constants/routes.ts
+++ b/apps/statgpt-admin-frontend/src/constants/routes.ts
@@ -1,0 +1,19 @@
+import { MenuUrl } from './menu';
+
+type Id = string | number;
+
+export const ROUTES = {
+  dataSources: MenuUrl.DATA_SOURCES,
+  dataSets: MenuUrl.DATA_SETS,
+  documents: MenuUrl.DOCUMENTS,
+  auditLogs: MenuUrl.AUDIT_LOGS,
+  channels: MenuUrl.CHANNELS,
+  channel: (channelId: Id) => `${MenuUrl.CHANNELS}/${channelId}`,
+  channelGlossary: (channelId: Id) =>
+    `${MenuUrl.CHANNELS}/${channelId}/glossary`,
+  channelJobs: (channelId: Id) => `${MenuUrl.CHANNELS}/${channelId}/jobs`,
+  datasetVersions: (channelId: Id, datasetId: Id) =>
+    `${MenuUrl.CHANNELS}/${channelId}/datasets/${datasetId}/versions`,
+  datasetAutoUpdateJobs: (channelId: Id, datasetId: Id) =>
+    `${MenuUrl.CHANNELS}/${channelId}/datasets/${datasetId}/auto-update-jobs`,
+} as const;

--- a/apps/statgpt-admin-frontend/src/context/AccessControlContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/AccessControlContext.tsx
@@ -3,8 +3,10 @@
 import {
   createContext,
   ReactNode,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import { usePathname } from 'next/navigation';
@@ -31,10 +33,11 @@ export function AccessControlProvider({ children }: { children: ReactNode }) {
     setIsForbidden(false);
   }, [pathname]);
 
+  const setForbidden = useCallback(() => setIsForbidden(true), []);
+  const value = useMemo(() => ({ setForbidden }), [setForbidden]);
+
   return (
-    <AccessControlContext.Provider
-      value={{ setForbidden: () => setIsForbidden(true) }}
-    >
+    <AccessControlContext.Provider value={value}>
       {isForbidden ? <NoAccessView /> : children}
     </AccessControlContext.Provider>
   );

--- a/apps/statgpt-admin-frontend/src/context/BreadcrumbContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/BreadcrumbContext.tsx
@@ -21,18 +21,15 @@ interface BreadcrumbContextValue {
   setBreadcrumbs: (crumbs: BreadcrumbEntry[]) => void;
 }
 
-const BreadcrumbContext = createContext<BreadcrumbContextValue | null>(null);
-
 const EMPTY: BreadcrumbEntry[] = [];
 
+const BreadcrumbContext = createContext<BreadcrumbContextValue>({
+  breadcrumbs: EMPTY,
+  setBreadcrumbs: () => {},
+});
+
 function useBreadcrumbContext(): BreadcrumbContextValue {
-  const ctx = useContext(BreadcrumbContext);
-  if (!ctx) {
-    throw new Error(
-      'useBreadcrumbs/useSetBreadcrumbs must be used within a BreadcrumbProvider',
-    );
-  }
-  return ctx;
+  return useContext(BreadcrumbContext);
 }
 
 export function useBreadcrumbs(): BreadcrumbEntry[] {

--- a/apps/statgpt-admin-frontend/src/context/BreadcrumbContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/BreadcrumbContext.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { usePathname } from 'next/navigation';
+
+export interface BreadcrumbEntry {
+  name: string;
+  href?: string;
+}
+
+interface BreadcrumbContextValue {
+  breadcrumbs: BreadcrumbEntry[];
+  setBreadcrumbs: (crumbs: BreadcrumbEntry[]) => void;
+}
+
+const BreadcrumbContext = createContext<BreadcrumbContextValue | null>(null);
+
+const EMPTY: BreadcrumbEntry[] = [];
+
+function useBreadcrumbContext(): BreadcrumbContextValue {
+  const ctx = useContext(BreadcrumbContext);
+  if (!ctx) {
+    throw new Error(
+      'useBreadcrumbs/useSetBreadcrumbs must be used within a BreadcrumbProvider',
+    );
+  }
+  return ctx;
+}
+
+export function useBreadcrumbs(): BreadcrumbEntry[] {
+  return useBreadcrumbContext().breadcrumbs;
+}
+
+export function useSetBreadcrumbs(crumbs: BreadcrumbEntry[]) {
+  const { setBreadcrumbs } = useBreadcrumbContext();
+  const key = crumbs.map((c) => `${c.name} ${c.href ?? ''}`).join('');
+
+  useEffect(() => {
+    setBreadcrumbs(crumbs);
+  }, [key, setBreadcrumbs]);
+}
+
+function shallowEqual(a: BreadcrumbEntry[], b: BreadcrumbEntry[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].name !== b[i].name || a[i].href !== b[i].href) return false;
+  }
+  return true;
+}
+
+interface BreadcrumbState {
+  pathname: string;
+  crumbs: BreadcrumbEntry[];
+}
+
+export function BreadcrumbProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [state, setState] = useState<BreadcrumbState>({ pathname, crumbs: [] });
+
+  const setBreadcrumbs = useCallback(
+    (next: BreadcrumbEntry[]) => {
+      setState((prev) =>
+        prev.pathname === pathname && shallowEqual(prev.crumbs, next)
+          ? prev
+          : { pathname, crumbs: next },
+      );
+    },
+    [pathname],
+  );
+
+  const breadcrumbs = state.pathname === pathname ? state.crumbs : EMPTY;
+
+  const value = useMemo(
+    () => ({ breadcrumbs, setBreadcrumbs }),
+    [breadcrumbs, setBreadcrumbs],
+  );
+
+  return (
+    <BreadcrumbContext.Provider value={value}>
+      {children}
+    </BreadcrumbContext.Provider>
+  );
+}

--- a/apps/statgpt-admin-frontend/src/context/ChannelDataContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/ChannelDataContext.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import { getChannel } from '@/src/app/channels/actions';
+import { Channel } from '@/src/models/channel';
+import { useAccessControl } from '@/src/context/AccessControlContext';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+
+interface ChannelDataContextValue {
+  channel: Channel | null;
+  isLoading: boolean;
+}
+
+const ChannelDataContext = createContext<ChannelDataContextValue>({
+  channel: null,
+  isLoading: true,
+});
+
+export function useChannelData() {
+  return useContext(ChannelDataContext);
+}
+
+interface ProviderProps {
+  channelId: string;
+  children: ReactNode;
+}
+
+export function ChannelDataProvider({ channelId, children }: ProviderProps) {
+  const { setForbidden } = useAccessControl();
+  const withNotification = useApiNotification();
+
+  const [channel, setChannel] = useState<Channel | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!channelId) return;
+
+    setIsLoading(true);
+    let cancelled = false;
+    withNotification(
+      getChannel(channelId),
+      'Failed to Load Channel',
+      [403],
+    ).then((result) => {
+      if (cancelled) return;
+      setIsLoading(false);
+      if (!result.ok) {
+        if (result.error.status === 403) setForbidden();
+        return;
+      }
+      setChannel(result.data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [channelId, setForbidden, withNotification]);
+
+  return (
+    <ChannelDataContext.Provider value={{ channel, isLoading }}>
+      {children}
+    </ChannelDataContext.Provider>
+  );
+}

--- a/apps/statgpt-admin-frontend/src/context/DatasetDataContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/DatasetDataContext.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import { getChannelDatasets } from '@/src/app/channels/actions';
+import { ChannelDataset } from '@/src/models/channel-dataset';
+import { useAccessControl } from '@/src/context/AccessControlContext';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+
+interface DatasetDataContextValue {
+  dataset: ChannelDataset | null;
+  isLoading: boolean;
+}
+
+const DatasetDataContext = createContext<DatasetDataContextValue>({
+  dataset: null,
+  isLoading: true,
+});
+
+export function useDatasetData() {
+  return useContext(DatasetDataContext);
+}
+
+interface ProviderProps {
+  channelId: string;
+  datasetId: string;
+  children: ReactNode;
+}
+
+export function DatasetDataProvider({
+  channelId,
+  datasetId,
+  children,
+}: ProviderProps) {
+  const { setForbidden } = useAccessControl();
+  const withNotification = useApiNotification();
+
+  const [dataset, setDataset] = useState<ChannelDataset | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!channelId || !datasetId) return;
+
+    setIsLoading(true);
+    let cancelled = false;
+    withNotification(
+      getChannelDatasets(channelId),
+      'Failed to Load Dataset',
+      [403],
+    ).then((result) => {
+      if (cancelled) return;
+      setIsLoading(false);
+      if (!result.ok) {
+        if (result.error.status === 403) setForbidden();
+        return;
+      }
+      const match =
+        result.data.data.find((ds) => String(ds.dataset_id) === datasetId) ??
+        null;
+      setDataset(match);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [channelId, datasetId, setForbidden, withNotification]);
+
+  return (
+    <DatasetDataContext.Provider value={{ dataset, isLoading }}>
+      {children}
+    </DatasetDataContext.Provider>
+  );
+}


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/171

### Description of changes

Breadcrumbs now display channel and dataset names instead of raw IDs, and the way breadcrumbs and the data behind them are managed has been refactored to avoid redundant API calls and make future pages easy to add.

**Breadcrumbs are now declared per-page**

Introduced a **BreadcrumbContext** (`useSetBreadcrumbs / useBreadcrumbs`). Each page declares its full breadcrumb chain with real names; **Header** just renders whatever the current page declared.
Removes the old path-parsing logic in **Header** that could only produce IDs and had to special-case every route. Adding breadcrumbs to a new page is now a single `useSetBreadcrumbs`([...]) call.

**Entity data fetched once and shared**

Added **ChannelDataProvider** and **DatasetDataProvider**, mounted in the `channels/[id]` and `datasets/[datasetId]` layouts so the **channel/dataset** is fetched once and reused by every sub-page (**overview, glossary, jobs, versions, auto-update jobs**).
Because the providers live in layouts, navigating between a dataset's sub-views no longer re-fetches.
**ChannelView**, **DatasetVersions**, and **AutoUpdateJobsView** now read from these contexts instead of making their own extra calls just to resolve a title.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
