### PR TITLE
feat: dataset deduplication with live status polling and notifications

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,3 +2,6 @@
 
 # picomatch
 CVE-2026-33671 exp:2026-06-20
+
+# libcrypto3, libssl3
+CVE-2026-45447

--- a/apps/statgpt-admin-frontend/src/app/channels/actions.ts
+++ b/apps/statgpt-admin-frontend/src/app/channels/actions.ts
@@ -4,6 +4,8 @@ import { cookies, headers } from 'next/headers';
 
 import { channelsApi } from '@/src/app/api/api';
 import { Channel, ChannelTerm } from '@/src/models/channel';
+import type { DeduplicationJob } from '@/src/models/deduplication-job';
+import type { ApiResult } from '@/src/server/api';
 import { getUserToken } from '@/src/utils/auth/get-token';
 import { getIsEnableAuthToggle } from '@/src/utils/get-auth-toggle';
 
@@ -25,13 +27,26 @@ export async function getChannel(id: string) {
   return channelsApi.getChannel(id, token);
 }
 
-export async function deduplicateDataset(id: string) {
+export async function deduplicateDataset(
+  id: string,
+): Promise<ApiResult<DeduplicationJob>> {
   const token = await getUserToken(
     getIsEnableAuthToggle(),
     headers(),
     cookies(),
   );
   return channelsApi.deduplicateDataset(id, token);
+}
+
+export async function getDeduplicationJob(
+  jobId: string | number,
+): Promise<ApiResult<DeduplicationJob>> {
+  const token = await getUserToken(
+    getIsEnableAuthToggle(),
+    headers(),
+    cookies(),
+  );
+  return channelsApi.getDeduplicationJob(jobId, token);
 }
 
 export async function removeChannel(id: string) {

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/Datasets.tsx
@@ -4,7 +4,6 @@ import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import {
-  deduplicateDataset,
   exportChannel,
   getChannelIndexStatus,
 } from '@/src/app/channels/actions';
@@ -57,6 +56,7 @@ import { DeduplicationStatsModal } from './DeduplicationStatsModal';
 import { LastVersionCheckCell } from './LastVersionCheckCell';
 import { VersionCell } from '@/src/components/GridView/VersionCell/VersionCell';
 import { ColDef } from 'ag-grid-community';
+import { useDeduplicationJobPolling } from './useDeduplicationJobPolling';
 
 interface Props {
   selectedChannelId?: string;
@@ -245,21 +245,6 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
     }),
   ];
 
-  const deduplicate = useCallback(() => {
-    withNotification(
-      deduplicateDataset(selectedChannelId as string),
-      'Deduplication Failed',
-    ).then((result) => {
-      if (result.ok) {
-        showNotification({
-          type: NotificationType.success,
-          title: 'Deduplication in progress',
-          description: 'The deduplication runs in the background',
-        });
-      }
-    });
-  }, [selectedChannelId]);
-
   const fetchIndexStatus = useCallback(() => {
     if (selectedChannelId != null) {
       getChannelIndexStatus(selectedChannelId).then((result) => {
@@ -270,6 +255,13 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
     }
   }, [selectedChannelId]);
 
+  const { deduplicate, isDeduplicationInProgress } = useDeduplicationJobPolling(
+    {
+      channelId: selectedChannelId,
+      onFinished: fetchIndexStatus,
+    },
+  );
+
   useEffect(() => {
     if (selectedChannelId != null && selectedChannelDataSets.length === 0) {
       updateDataSet();
@@ -278,7 +270,7 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
 
   useEffect(() => {
     fetchIndexStatus();
-  }, [selectedChannelId]);
+  }, [fetchIndexStatus]);
 
   const recalculateIndexes = (mode: 'sequential' | 'parallel') => {
     setPendingRecalculateMode(null);
@@ -406,7 +398,7 @@ export const DataSetsView: FC<Props> = ({ selectedChannelId }) => {
           />
         </div>
       </div>
-      {deduplicationRequired && (
+      {deduplicationRequired && !isDeduplicationInProgress && (
         <DeduplicationAlert onDeduplicate={deduplicate} />
       )}
       <div className="flex-1 min-h-0">

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
@@ -20,6 +20,14 @@ const DEDUPLICATION_JOB_POLL_INTERVAL_MS = 2000;
 const getDeduplicationStatusLabel = (status: DeduplicationJobStatus) =>
   DEDUPLICATION_JOB_STATUS_LABEL[status] ?? status;
 
+const DEDUPLICATION_JOB_STATUS_TITLE: Partial<
+  Record<DeduplicationJobStatus, string>
+> = {
+  [DeduplicationJobStatus.NOT_STARTED]: 'Duplicates removal not started',
+  [DeduplicationJobStatus.QUEUED]: 'Duplicates removal queued',
+  [DeduplicationJobStatus.IN_PROGRESS]: 'Removing duplicates',
+};
+
 const getDeduplicationSuccessDescription = (job: DeduplicationJob) =>
   [
     `Non-indicator remapped: ${job.non_indicator_remapped}`,
@@ -47,6 +55,13 @@ export const useDeduplicationJobPolling = ({
   const notificationIdRef = useRef<string | null>(null);
   const lastStatusRef = useRef<DeduplicationJobStatus | null>(null);
   const operationIdRef = useRef(0);
+  const showNotificationRef = useRef(showNotification);
+  const removeNotificationRef = useRef(removeNotification);
+  const onFinishedRef = useRef(onFinished);
+
+  showNotificationRef.current = showNotification;
+  removeNotificationRef.current = removeNotification;
+  onFinishedRef.current = onFinished;
 
   const clearPolling = useCallback(() => {
     if (pollingTimeoutRef.current != null) {
@@ -57,17 +72,17 @@ export const useDeduplicationJobPolling = ({
 
   const clearNotification = useCallback(() => {
     if (notificationIdRef.current != null) {
-      removeNotification(notificationIdRef.current);
+      removeNotificationRef.current(notificationIdRef.current);
       notificationIdRef.current = null;
     }
-  }, [removeNotification]);
+  }, []);
 
   const replaceNotification = useCallback(
     (notification: Parameters<typeof showNotification>[0]) => {
       clearNotification();
-      notificationIdRef.current = showNotification(notification);
+      notificationIdRef.current = showNotificationRef.current(notification);
     },
-    [clearNotification, showNotification],
+    [clearNotification],
   );
 
   const showStatusNotification = useCallback(
@@ -82,7 +97,8 @@ export const useDeduplicationJobPolling = ({
       lastStatusRef.current = job.status;
       replaceNotification({
         type: NotificationType.loading,
-        title: 'Removing duplicates',
+        title:
+          DEDUPLICATION_JOB_STATUS_TITLE[job.status] || 'Removing duplicates',
         description: `Job #${job.id}: ${getDeduplicationStatusLabel(job.status)}`,
         duration: null,
       });
@@ -97,10 +113,10 @@ export const useDeduplicationJobPolling = ({
       lastStatusRef.current = null;
       operationIdRef.current += 1;
       setIsDeduplicationInProgress(false);
-      onFinished();
+      onFinishedRef.current();
 
       if (job.status === DeduplicationJobStatus.FAILED) {
-        showNotification({
+        showNotificationRef.current({
           type: NotificationType.error,
           title: 'Duplicates removal failed',
           description:
@@ -110,13 +126,13 @@ export const useDeduplicationJobPolling = ({
         return;
       }
 
-      showNotification({
+      showNotificationRef.current({
         type: NotificationType.success,
         title: 'Duplicate removal succeeded',
         description: getDeduplicationSuccessDescription(job),
       });
     },
-    [clearNotification, clearPolling, onFinished, showNotification],
+    [clearNotification, clearPolling],
   );
 
   const handleJob = useCallback(
@@ -151,7 +167,7 @@ export const useDeduplicationJobPolling = ({
           lastStatusRef.current = null;
           operationIdRef.current += 1;
           setIsDeduplicationInProgress(false);
-          showNotification({
+          showNotificationRef.current({
             type: NotificationType.error,
             title: 'Deduplication status check failed',
             description:
@@ -174,7 +190,7 @@ export const useDeduplicationJobPolling = ({
         DEDUPLICATION_JOB_POLL_INTERVAL_MS,
       );
     },
-    [clearNotification, clearPolling, handleJob, showNotification],
+    [clearNotification, clearPolling, handleJob],
   );
 
   const deduplicate = useCallback(() => {

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
@@ -1,0 +1,238 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  deduplicateDataset,
+  getDeduplicationJob,
+} from '@/src/app/channels/actions';
+import { useNotification } from '@/src/context/NotificationContext';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+import {
+  DEDUPLICATION_JOB_STATUS_LABEL,
+  DeduplicationJobStatus,
+  type DeduplicationJob,
+} from '@/src/models/deduplication-job';
+import { NotificationType } from '@/src/models/notification';
+
+const DEDUPLICATION_JOB_POLL_INTERVAL_MS = 2000;
+
+const getDeduplicationStatusLabel = (status: DeduplicationJobStatus) =>
+  DEDUPLICATION_JOB_STATUS_LABEL[status] ?? status;
+
+const getDeduplicationSuccessDescription = (job: DeduplicationJob) =>
+  [
+    `Non-indicator remapped: ${job.non_indicator_remapped}`,
+    `Special remapped: ${job.special_remapped}`,
+    `Non-indicator deleted: ${job.non_indicator_deleted}`,
+    `Special deleted: ${job.special_deleted}`,
+  ].join('\n');
+
+interface UseDeduplicationJobPollingParams {
+  channelId?: string;
+  onFinished: () => void;
+}
+
+export const useDeduplicationJobPolling = ({
+  channelId,
+  onFinished,
+}: UseDeduplicationJobPollingParams) => {
+  const { showNotification, removeNotification } = useNotification();
+  const withNotification = useApiNotification();
+
+  const [isDeduplicationInProgress, setIsDeduplicationInProgress] =
+    useState(false);
+
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const notificationIdRef = useRef<string | null>(null);
+  const lastStatusRef = useRef<DeduplicationJobStatus | null>(null);
+  const operationIdRef = useRef(0);
+
+  const clearPolling = useCallback(() => {
+    if (pollingTimeoutRef.current != null) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearNotification = useCallback(() => {
+    if (notificationIdRef.current != null) {
+      removeNotification(notificationIdRef.current);
+      notificationIdRef.current = null;
+    }
+  }, [removeNotification]);
+
+  const replaceNotification = useCallback(
+    (notification: Parameters<typeof showNotification>[0]) => {
+      clearNotification();
+      notificationIdRef.current = showNotification(notification);
+    },
+    [clearNotification, showNotification],
+  );
+
+  const showStatusNotification = useCallback(
+    (job: DeduplicationJob) => {
+      if (
+        notificationIdRef.current != null &&
+        lastStatusRef.current === job.status
+      ) {
+        return;
+      }
+
+      lastStatusRef.current = job.status;
+      replaceNotification({
+        type: NotificationType.loading,
+        title: 'Removing duplicates',
+        description: `Job #${job.id}: ${getDeduplicationStatusLabel(job.status)}`,
+        duration: null,
+      });
+    },
+    [replaceNotification],
+  );
+
+  const showFinalNotification = useCallback(
+    (job: DeduplicationJob) => {
+      clearPolling();
+      clearNotification();
+      lastStatusRef.current = null;
+      operationIdRef.current += 1;
+      setIsDeduplicationInProgress(false);
+      onFinished();
+
+      if (job.status === DeduplicationJobStatus.FAILED) {
+        showNotification({
+          type: NotificationType.error,
+          title: 'Duplicates removal failed',
+          description:
+            job.reason_for_failure?.trim() ||
+            'Unable to remove duplicates. Please try again.',
+        });
+        return;
+      }
+
+      showNotification({
+        type: NotificationType.success,
+        title: 'Duplicate removal succeeded',
+        description: getDeduplicationSuccessDescription(job),
+      });
+    },
+    [clearNotification, clearPolling, onFinished, showNotification],
+  );
+
+  const handleJob = useCallback(
+    (job: DeduplicationJob) => {
+      if (
+        job.status === DeduplicationJobStatus.COMPLETED ||
+        job.status === DeduplicationJobStatus.FAILED
+      ) {
+        showFinalNotification(job);
+        return true;
+      }
+
+      showStatusNotification(job);
+      return false;
+    },
+    [showFinalNotification, showStatusNotification],
+  );
+
+  const startPolling = useCallback(
+    (jobId: number, operationId: number) => {
+      clearPolling();
+
+      const poll = async () => {
+        const result = await getDeduplicationJob(jobId);
+        if (operationIdRef.current !== operationId) {
+          return;
+        }
+
+        if (!result.ok) {
+          clearPolling();
+          clearNotification();
+          lastStatusRef.current = null;
+          operationIdRef.current += 1;
+          setIsDeduplicationInProgress(false);
+          showNotification({
+            type: NotificationType.error,
+            title: 'Deduplication status check failed',
+            description:
+              result.error.message ||
+              'Unable to check deduplication status. Please try again.',
+          });
+          return;
+        }
+
+        if (!handleJob(result.data)) {
+          pollingTimeoutRef.current = setTimeout(
+            poll,
+            DEDUPLICATION_JOB_POLL_INTERVAL_MS,
+          );
+        }
+      };
+
+      pollingTimeoutRef.current = setTimeout(
+        poll,
+        DEDUPLICATION_JOB_POLL_INTERVAL_MS,
+      );
+    },
+    [clearNotification, clearPolling, handleJob, showNotification],
+  );
+
+  const deduplicate = useCallback(() => {
+    if (channelId == null) {
+      return;
+    }
+
+    const operationId = operationIdRef.current + 1;
+    operationIdRef.current = operationId;
+    clearPolling();
+    clearNotification();
+    lastStatusRef.current = null;
+    setIsDeduplicationInProgress(true);
+
+    withNotification(
+      deduplicateDataset(channelId),
+      'Deduplication Failed',
+    ).then((result) => {
+      if (operationIdRef.current !== operationId) {
+        return;
+      }
+
+      if (result.ok) {
+        if (!handleJob(result.data)) {
+          startPolling(result.data.id, operationId);
+        }
+      } else {
+        setIsDeduplicationInProgress(false);
+      }
+    });
+  }, [
+    channelId,
+    clearNotification,
+    clearPolling,
+    handleJob,
+    startPolling,
+    withNotification,
+  ]);
+
+  useEffect(() => {
+    operationIdRef.current += 1;
+    clearPolling();
+    clearNotification();
+    lastStatusRef.current = null;
+    setIsDeduplicationInProgress(false);
+  }, [channelId, clearNotification, clearPolling]);
+
+  useEffect(() => {
+    return () => {
+      operationIdRef.current += 1;
+      clearPolling();
+      clearNotification();
+      lastStatusRef.current = null;
+    };
+  }, [clearNotification, clearPolling]);
+
+  return {
+    deduplicate,
+    isDeduplicationInProgress,
+  };
+};

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
@@ -9,16 +9,13 @@ import {
 import { useNotification } from '@/src/context/NotificationContext';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
 import {
-  DEDUPLICATION_JOB_STATUS_LABEL,
   DeduplicationJobStatus,
   type DeduplicationJob,
 } from '@/src/models/deduplication-job';
 import { NotificationType } from '@/src/models/notification';
 
 const DEDUPLICATION_JOB_POLL_INTERVAL_MS = 5000;
-
-const getDeduplicationStatusLabel = (status: DeduplicationJobStatus) =>
-  DEDUPLICATION_JOB_STATUS_LABEL[status] ?? status;
+const DEDUPLICATION_JOB_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
 const DEDUPLICATION_JOB_STATUS_TITLE: Record<DeduplicationJobStatus, string> = {
   [DeduplicationJobStatus.NOT_STARTED]: 'Duplicate removal not started',
@@ -26,6 +23,20 @@ const DEDUPLICATION_JOB_STATUS_TITLE: Record<DeduplicationJobStatus, string> = {
   [DeduplicationJobStatus.IN_PROGRESS]: 'Removing duplicates',
   [DeduplicationJobStatus.COMPLETED]: 'Duplicate removal completed',
   [DeduplicationJobStatus.FAILED]: 'Duplicate removal failed',
+};
+
+const DEDUPLICATION_JOB_STATUS_DESCRIPTION: Record<
+  DeduplicationJobStatus,
+  string
+> = {
+  [DeduplicationJobStatus.NOT_STARTED]:
+    'Preparing to remove duplicate records…',
+  [DeduplicationJobStatus.QUEUED]:
+    'Your request is in the queue and will start shortly.',
+  [DeduplicationJobStatus.IN_PROGRESS]:
+    'This can take a few minutes — you can keep working in the meantime.',
+  [DeduplicationJobStatus.COMPLETED]: 'Duplicate removal completed.',
+  [DeduplicationJobStatus.FAILED]: 'Duplicate removal failed.',
 };
 
 const getDeduplicationSuccessDescription = (job: DeduplicationJob) =>
@@ -52,6 +63,7 @@ export const useDeduplicationJobPolling = ({
     useState(false);
 
   const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollingStartedAtRef = useRef<number | null>(null);
   const notificationIdRef = useRef<string | null>(null);
   const lastStatusRef = useRef<DeduplicationJobStatus | null>(null);
   const operationIdRef = useRef(0);
@@ -85,6 +97,17 @@ export const useDeduplicationJobPolling = ({
     [clearNotification],
   );
 
+  const resetState = useCallback(
+    (inProgress: boolean) => {
+      clearPolling();
+      clearNotification();
+      lastStatusRef.current = null;
+      operationIdRef.current += 1;
+      setIsDeduplicationInProgress(inProgress);
+    },
+    [clearNotification, clearPolling],
+  );
+
   const showStatusNotification = useCallback(
     (job: DeduplicationJob) => {
       if (
@@ -98,8 +121,12 @@ export const useDeduplicationJobPolling = ({
       replaceNotification({
         type: NotificationType.loading,
         title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
-        description: `Job #${job.id}: ${getDeduplicationStatusLabel(job.status)}`,
+        description: DEDUPLICATION_JOB_STATUS_DESCRIPTION[job.status],
         duration: null,
+        onClose: () => {
+          notificationIdRef.current = null;
+          lastStatusRef.current = null;
+        },
       });
     },
     [replaceNotification],
@@ -107,11 +134,7 @@ export const useDeduplicationJobPolling = ({
 
   const showFinalNotification = useCallback(
     (job: DeduplicationJob) => {
-      clearPolling();
-      clearNotification();
-      lastStatusRef.current = null;
-      operationIdRef.current += 1;
-      setIsDeduplicationInProgress(false);
+      resetState(false);
       onFinishedRef.current();
 
       if (job.status === DeduplicationJobStatus.FAILED) {
@@ -131,7 +154,7 @@ export const useDeduplicationJobPolling = ({
         description: getDeduplicationSuccessDescription(job),
       });
     },
-    [clearNotification, clearPolling],
+    [resetState],
   );
 
   const handleJob = useCallback(
@@ -153,6 +176,7 @@ export const useDeduplicationJobPolling = ({
   const startPolling = useCallback(
     (jobId: number, operationId: number) => {
       clearPolling();
+      pollingStartedAtRef.current = Date.now();
 
       const poll = async () => {
         const result = await getDeduplicationJob(jobId);
@@ -161,11 +185,7 @@ export const useDeduplicationJobPolling = ({
         }
 
         if (!result.ok) {
-          clearPolling();
-          clearNotification();
-          lastStatusRef.current = null;
-          operationIdRef.current += 1;
-          setIsDeduplicationInProgress(false);
+          resetState(false);
           showNotificationRef.current({
             type: NotificationType.error,
             title: 'Deduplication status check failed',
@@ -176,12 +196,29 @@ export const useDeduplicationJobPolling = ({
           return;
         }
 
-        if (!handleJob(result.data)) {
-          pollingTimeoutRef.current = setTimeout(
-            poll,
-            DEDUPLICATION_JOB_POLL_INTERVAL_MS,
-          );
+        if (handleJob(result.data)) {
+          return;
         }
+
+        const elapsed =
+          pollingStartedAtRef.current != null
+            ? Date.now() - pollingStartedAtRef.current
+            : 0;
+        if (elapsed >= DEDUPLICATION_JOB_POLL_TIMEOUT_MS) {
+          resetState(false);
+          showNotificationRef.current({
+            type: NotificationType.error,
+            title: 'Deduplication is taking longer than expected',
+            description:
+              'Duplicate removal is still running in the background. Please check back later.',
+          });
+          return;
+        }
+
+        pollingTimeoutRef.current = setTimeout(
+          poll,
+          DEDUPLICATION_JOB_POLL_INTERVAL_MS,
+        );
       };
 
       pollingTimeoutRef.current = setTimeout(
@@ -189,7 +226,7 @@ export const useDeduplicationJobPolling = ({
         DEDUPLICATION_JOB_POLL_INTERVAL_MS,
       );
     },
-    [clearNotification, clearPolling, handleJob],
+    [clearPolling, handleJob, resetState],
   );
 
   const deduplicate = useCallback(() => {
@@ -197,12 +234,8 @@ export const useDeduplicationJobPolling = ({
       return;
     }
 
-    const operationId = operationIdRef.current + 1;
-    operationIdRef.current = operationId;
-    clearPolling();
-    clearNotification();
-    lastStatusRef.current = null;
-    setIsDeduplicationInProgress(true);
+    resetState(true);
+    const operationId = operationIdRef.current;
 
     withNotification(
       deduplicateDataset(channelId),
@@ -220,31 +253,17 @@ export const useDeduplicationJobPolling = ({
         setIsDeduplicationInProgress(false);
       }
     });
-  }, [
-    channelId,
-    clearNotification,
-    clearPolling,
-    handleJob,
-    startPolling,
-    withNotification,
-  ]);
+  }, [channelId, resetState, handleJob, startPolling, withNotification]);
 
   useEffect(() => {
-    operationIdRef.current += 1;
-    clearPolling();
-    clearNotification();
-    lastStatusRef.current = null;
-    setIsDeduplicationInProgress(false);
-  }, [channelId, clearNotification, clearPolling]);
-
-  useEffect(() => {
+    resetState(false);
     return () => {
-      operationIdRef.current += 1;
       clearPolling();
       clearNotification();
       lastStatusRef.current = null;
+      operationIdRef.current += 1;
     };
-  }, [clearNotification, clearPolling]);
+  }, [channelId, resetState, clearPolling, clearNotification]);
 
   return {
     deduplicate,

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
@@ -15,17 +15,17 @@ import {
 } from '@/src/models/deduplication-job';
 import { NotificationType } from '@/src/models/notification';
 
-const DEDUPLICATION_JOB_POLL_INTERVAL_MS = 2000;
+const DEDUPLICATION_JOB_POLL_INTERVAL_MS = 5000;
 
 const getDeduplicationStatusLabel = (status: DeduplicationJobStatus) =>
   DEDUPLICATION_JOB_STATUS_LABEL[status] ?? status;
 
-const DEDUPLICATION_JOB_STATUS_TITLE: Partial<
-  Record<DeduplicationJobStatus, string>
-> = {
-  [DeduplicationJobStatus.NOT_STARTED]: 'Duplicates removal not started',
-  [DeduplicationJobStatus.QUEUED]: 'Duplicates removal queued',
+const DEDUPLICATION_JOB_STATUS_TITLE: Record<DeduplicationJobStatus, string> = {
+  [DeduplicationJobStatus.NOT_STARTED]: 'Duplicate removal not started',
+  [DeduplicationJobStatus.QUEUED]: 'Duplicate removal queued',
   [DeduplicationJobStatus.IN_PROGRESS]: 'Removing duplicates',
+  [DeduplicationJobStatus.COMPLETED]: 'Duplicate removal completed',
+  [DeduplicationJobStatus.FAILED]: 'Duplicate removal failed',
 };
 
 const getDeduplicationSuccessDescription = (job: DeduplicationJob) =>
@@ -97,8 +97,7 @@ export const useDeduplicationJobPolling = ({
       lastStatusRef.current = job.status;
       replaceNotification({
         type: NotificationType.loading,
-        title:
-          DEDUPLICATION_JOB_STATUS_TITLE[job.status] || 'Removing duplicates',
+        title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
         description: `Job #${job.id}: ${getDeduplicationStatusLabel(job.status)}`,
         duration: null,
       });
@@ -118,7 +117,7 @@ export const useDeduplicationJobPolling = ({
       if (job.status === DeduplicationJobStatus.FAILED) {
         showNotificationRef.current({
           type: NotificationType.error,
-          title: 'Duplicates removal failed',
+          title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
           description:
             job.reason_for_failure?.trim() ||
             'Unable to remove duplicates. Please try again.',
@@ -128,7 +127,7 @@ export const useDeduplicationJobPolling = ({
 
       showNotificationRef.current({
         type: NotificationType.success,
-        title: 'Duplicate removal succeeded',
+        title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
         description: getDeduplicationSuccessDescription(job),
       });
     },

--- a/apps/statgpt-admin-frontend/src/context/NotificationContext.tsx
+++ b/apps/statgpt-admin-frontend/src/context/NotificationContext.tsx
@@ -35,6 +35,7 @@ export const NotificationProvider: FC<{ children: ReactNode }> = ({
         ...notification,
         id,
         onClose: () => {
+          notification.onClose?.();
           return removeNotification(id);
         },
       },

--- a/apps/statgpt-admin-frontend/src/models/deduplication-job.ts
+++ b/apps/statgpt-admin-frontend/src/models/deduplication-job.ts
@@ -1,0 +1,31 @@
+export enum DeduplicationJobStatus {
+  NOT_STARTED = 'NOT_STARTED',
+  QUEUED = 'QUEUED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+export const DEDUPLICATION_JOB_STATUS_LABEL: Record<
+  DeduplicationJobStatus,
+  string
+> = {
+  [DeduplicationJobStatus.NOT_STARTED]: 'Not started',
+  [DeduplicationJobStatus.QUEUED]: 'Queued',
+  [DeduplicationJobStatus.IN_PROGRESS]: 'In progress',
+  [DeduplicationJobStatus.COMPLETED]: 'Completed',
+  [DeduplicationJobStatus.FAILED]: 'Failed',
+};
+
+export interface DeduplicationJob {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  channel_id: number;
+  status: DeduplicationJobStatus;
+  reason_for_failure: string;
+  non_indicator_remapped: number;
+  non_indicator_deleted: number;
+  special_remapped: number;
+  special_deleted: number;
+}

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -20,6 +20,7 @@ import { AutoUpdateJob } from '@/src/models/auto-update-job';
 import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
 import { Job, JobStatus } from '@/src/models/job';
+import { DeduplicationJob } from '@/src/models/deduplication-job';
 
 export const CHANNELS_URL = `${MAIN_API}/channels`;
 export const CHANNELS_IMPORT_URL = `${CHANNELS_URL}/import`;
@@ -47,6 +48,10 @@ export const CHANNEL_DATA_SETS_URL = (id: string | number): string =>
 
 export const CHANNEL_DEDUPLICATE_URL = (id: string | number): string =>
   `${CHANNEL_DATA_SETS_URL(id)}/deduplicate`;
+
+export const CHANNELS_DEDUPLICATION_JOB_ID_URL = (
+  jobId: string | number,
+): string => `${CHANNELS_URL}/deduplication-jobs/${jobId}`;
 
 export const RELOAD_ALL_DATASETS_CHANNEL_URL = (id: string | number): string =>
   `${CHANNEL_DATA_SETS_URL(id)}/reload-indicators`;
@@ -274,8 +279,15 @@ export class ChannelsApi extends BaseApi {
   deduplicateDataset(
     id: string,
     token: JWT | null,
-  ): Promise<ApiResult<RequestData<DataSet>>> {
-    return this.post(CHANNEL_DEDUPLICATE_URL(id), {}, void 0, {}, token);
+  ): Promise<ApiResult<DeduplicationJob>> {
+    return this.post(CHANNEL_DEDUPLICATE_URL(id), {}, void 0, void 0, token);
+  }
+
+  getDeduplicationJob(
+    jobId: string | number,
+    token: JWT | null,
+  ): Promise<ApiResult<DeduplicationJob>> {
+    return this.get(CHANNELS_DEDUPLICATION_JOB_ID_URL(jobId), token);
   }
 
   removeChannelDataset(


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-admin-frontend/issues/186

### Description of changes

Adds a `useDeduplicationJobPolling` hook that drives the deduplication flow end to end:

- **Trigger & track** – calls the `deduplicateDataset` server action, then polls `getDeduplicationJob` every **5s** until the job reaches `COMPLETED/FAILED`.
- **User-facing notifications** – a persistent loading toast, status-specific messaging while the job runs; a success toast summarizing remapped/deleted counts; an error toast (with the backend's failure reason) on failure or status-check error.
- **Bounded polling** – stops after a 5-minute cap with a "still running in the background" notice.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
