### PR TITLE
feat: show validation and indexing status in discovery datasets grid

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DetailsView/DiscoveryDatasetDetailsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DetailsView/DiscoveryDatasetDetailsView.tsx
@@ -5,23 +5,17 @@ import { FC } from 'react';
 import { DataField } from '@/src/components/BaseComponents/DataField/DataField';
 import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { Modal } from '@/src/components/Modal/Modal';
-import { DiscoveryDataset } from '@/src/models/discovery-dataset';
+import {
+  DISCOVERY_INDEXING_STATUS_LABEL,
+  DISCOVERY_VALIDATION_STATUS_LABEL,
+  DiscoveryDataset,
+  formatDiscoveryValidationIssues,
+} from '@/src/models/discovery-dataset';
 
 interface Props {
   data: DiscoveryDataset;
   close: () => void;
 }
-
-const formatValidationIssues = (
-  issues?: DiscoveryDataset['validationIssues'],
-): string => {
-  if (!issues || !issues.length) return '';
-  return issues
-    .map((issue) =>
-      issue.field ? `${issue.field}: ${issue.message}` : issue.message,
-    )
-    .join('; ');
-};
 
 export const DiscoveryDatasetDetailsView: FC<Props> = ({ data, close }) => {
   return (
@@ -49,13 +43,25 @@ export const DiscoveryDatasetDetailsView: FC<Props> = ({ data, close }) => {
         />
         <DataField label="Missing Indicators" value={data.missingIndicators} />
         <DataField label="Channel ID" value={String(data.channelId ?? '')} />
-        <DataField label="Validation Status" value={data.validationStatus} />
+        <DataField
+          label="Validation Status"
+          value={
+            data.validationStatus &&
+            DISCOVERY_VALIDATION_STATUS_LABEL[data.validationStatus]
+          }
+        />
         <DataField
           label="Validation Issues"
-          value={formatValidationIssues(data.validationIssues)}
+          value={formatDiscoveryValidationIssues(data.validationIssues)}
         />
         <DataField label="Validated At" value={data.validatedAt} />
-        <DataField label="Indexing Status" value={data.indexingStatus} />
+        <DataField
+          label="Indexing Status"
+          value={
+            data.indexingStatus &&
+            DISCOVERY_INDEXING_STATUS_LABEL[data.indexingStatus]
+          }
+        />
         <DataField label="Indexed At" value={data.indexedAt} />
         <DataField label="Index Error" value={data.indexError} />
       </div>

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -19,6 +19,8 @@ import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { DiscoveryDataset } from '@/src/models/discovery-dataset';
 import { RequestData } from '@/src/models/request-data';
 import { sendGetRequest } from '@/src/server/api';
+import { ValidationStatusCell } from '@/src/components/GridView/ValidationStatusCell/ValidationStatusCell';
+import { IndexingStatusCell } from '@/src/components/GridView/IndexingStatusCell/IndexingStatusCell';
 import { DiscoveryDatasetActionColumn } from './ActionColumn/ActionColumn';
 import { UploadModal } from './UploadModal/UploadModal';
 
@@ -31,12 +33,20 @@ const COLUMNS: ColDef[] = [
   { field: 'agency', headerName: 'Agency' },
   { field: 'datasetId', headerName: 'Dataset ID' },
   { field: 'name', headerName: 'Name' },
-  { field: 'description', headerName: 'Description' },
   { field: 'url', headerName: 'URL' },
   { field: 'referenceArea', headerName: 'Reference Area' },
   { field: 'timeCoverage', headerName: 'Time Coverage' },
   { field: 'frequencyCoverage', headerName: 'Frequency Coverage' },
-  { field: 'indexingStatus', headerName: 'Indexing Status' },
+  {
+    field: 'validationStatus',
+    headerName: 'Validation Status',
+    cellRenderer: ValidationStatusCell,
+  },
+  {
+    field: 'indexingStatus',
+    headerName: 'Indexing Status',
+    cellRenderer: IndexingStatusCell,
+  },
   {
     width: 32,
     maxWidth: 32,

--- a/apps/statgpt-admin-frontend/src/components/GridView/IndexingStatusCell/IndexingStatusCell.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/IndexingStatusCell/IndexingStatusCell.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { ICellRendererParams } from 'ag-grid-community';
+
+import { DiscoveryDataset } from '@/src/models/discovery-dataset';
+import { StatusIconCell } from '@/src/components/GridView/StatusIconCell/StatusIconCell';
+import { DISCOVERY_INDEXING_STATUS_VISUALS } from './discovery-indexing-status-visuals';
+
+export const IndexingStatusCell = (
+  params: ICellRendererParams<DiscoveryDataset>,
+) => (
+  <StatusIconCell
+    {...params}
+    config={DISCOVERY_INDEXING_STATUS_VISUALS}
+    tooltip={(data) => data?.indexError}
+  />
+);

--- a/apps/statgpt-admin-frontend/src/components/GridView/IndexingStatusCell/discovery-indexing-status-visuals.ts
+++ b/apps/statgpt-admin-frontend/src/components/GridView/IndexingStatusCell/discovery-indexing-status-visuals.ts
@@ -1,0 +1,38 @@
+import {
+  IconAlertTriangle,
+  IconClock,
+  IconExclamationCircle,
+} from '@tabler/icons-react';
+
+import {
+  DISCOVERY_INDEXING_STATUS_LABEL,
+  DiscoveryIndexingStatus,
+} from '@/src/models/discovery-dataset';
+import { CheckIcon } from '@/src/components/GridView/StatusIconCell/CheckIcon';
+import { StatusVisual } from '@/src/components/GridView/StatusIconCell/types';
+
+export const DISCOVERY_INDEXING_STATUS_VISUALS: Record<
+  DiscoveryIndexingStatus,
+  StatusVisual
+> = {
+  [DiscoveryIndexingStatus.New]: {
+    label: DISCOVERY_INDEXING_STATUS_LABEL[DiscoveryIndexingStatus.New],
+    icon: IconClock,
+    iconColorClass: 'text-icon-secondary',
+  },
+  [DiscoveryIndexingStatus.Outdated]: {
+    label: DISCOVERY_INDEXING_STATUS_LABEL[DiscoveryIndexingStatus.Outdated],
+    icon: IconAlertTriangle,
+    iconColorClass: 'text-icon-warning',
+  },
+  [DiscoveryIndexingStatus.Indexed]: {
+    label: DISCOVERY_INDEXING_STATUS_LABEL[DiscoveryIndexingStatus.Indexed],
+    icon: CheckIcon,
+  },
+  [DiscoveryIndexingStatus.Failed]: {
+    label: DISCOVERY_INDEXING_STATUS_LABEL[DiscoveryIndexingStatus.Failed],
+    icon: IconExclamationCircle,
+    iconColorClass: 'text-icon-error',
+    textColorClass: 'text-error',
+  },
+};

--- a/apps/statgpt-admin-frontend/src/components/GridView/PreprocessingStatusCell/PreprocessingStatusCell.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/PreprocessingStatusCell/PreprocessingStatusCell.tsx
@@ -2,39 +2,19 @@
 
 import { ICellRendererParams } from 'ag-grid-community';
 
-import {
-  PREPROCESSING_STATUS_LABEL,
-  PreprocessingStatus,
-} from '@/src/models/preprocessing-status';
-import { PreprocessingStatusIcon } from './PreprocessingStatusIcon';
-import { mergeClasses } from '@/src/utils/mergeClasses';
+import { StatusIconCell } from '@/src/components/GridView/StatusIconCell/StatusIconCell';
+import { PREPROCESSING_STATUS_VISUALS } from './preprocessing-status-visuals';
 
 interface WithFailureReason {
   reason_for_failure: string;
 }
 
-export const PreprocessingStatusCell = ({
-  value,
-  data,
-}: ICellRendererParams<WithFailureReason>) => {
-  if (value == null || value === '') return null;
-
-  const status = value as PreprocessingStatus;
-  const label = PREPROCESSING_STATUS_LABEL[status] ?? String(value);
-  const isFailed = status === PreprocessingStatus.FAILED;
-
-  return (
-    <div
-      className={mergeClasses(
-        'flex items-center w-full',
-        isFailed && 'text-error',
-      )}
-    >
-      <span>{label}</span>
-      <PreprocessingStatusIcon
-        status={status}
-        failureReason={data?.reason_for_failure}
-      />
-    </div>
-  );
-};
+export const PreprocessingStatusCell = (
+  params: ICellRendererParams<WithFailureReason>,
+) => (
+  <StatusIconCell
+    {...params}
+    config={PREPROCESSING_STATUS_VISUALS}
+    tooltip={(data) => data?.reason_for_failure}
+  />
+);

--- a/apps/statgpt-admin-frontend/src/components/GridView/PreprocessingStatusCell/PreprocessingStatusIcon.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/PreprocessingStatusCell/PreprocessingStatusIcon.tsx
@@ -1,14 +1,8 @@
 'use client';
 
-import {
-  IconClock,
-  IconExclamationCircle,
-  IconLoader4,
-} from '@tabler/icons-react';
-
-import Check from '@/public/icons/check.svg';
 import { PreprocessingStatus } from '@/src/models/preprocessing-status';
-import { Tooltip } from '@/src/components/BaseComponents/Tooltip/Tooltip';
+import { StatusIcon } from '@/src/components/GridView/StatusIconCell/StatusIcon';
+import { PREPROCESSING_STATUS_VISUALS } from './preprocessing-status-visuals';
 
 interface Props {
   status: PreprocessingStatus;
@@ -16,44 +10,13 @@ interface Props {
 }
 
 export const PreprocessingStatusIcon = ({ status, failureReason }: Props) => {
-  switch (status) {
-    case PreprocessingStatus.COMPLETED:
-      return (
-        <Check className="[&_path]:fill-[var(--icon-accent-secondary,#37BABC)] size-4 flex-shrink-0 ml-auto" />
-      );
+  const visual = PREPROCESSING_STATUS_VISUALS[status];
 
-    case PreprocessingStatus.FAILED:
-      return failureReason ? (
-        <Tooltip content={failureReason} className="ml-auto flex-shrink-0">
-          <IconExclamationCircle
-            size={16}
-            className="text-icon-error cursor-help"
-          />
-        </Tooltip>
-      ) : (
-        <IconExclamationCircle
-          size={16}
-          className="text-icon-error flex-shrink-0 ml-auto"
-        />
-      );
-
-    case PreprocessingStatus.IN_PROGRESS:
-      return (
-        <IconLoader4
-          size={16}
-          className="text-icon-accent-primary flex-shrink-0 ml-auto"
-        />
-      );
-
-    case PreprocessingStatus.QUEUED:
-      return (
-        <IconClock
-          size={16}
-          className="text-icon-secondary flex-shrink-0 ml-auto"
-        />
-      );
-
-    default:
-      return null;
-  }
+  return (
+    <StatusIcon
+      icon={visual?.icon}
+      colorClass={visual?.iconColorClass}
+      tooltipContent={failureReason}
+    />
+  );
 };

--- a/apps/statgpt-admin-frontend/src/components/GridView/PreprocessingStatusCell/preprocessing-status-visuals.ts
+++ b/apps/statgpt-admin-frontend/src/components/GridView/PreprocessingStatusCell/preprocessing-status-visuals.ts
@@ -1,0 +1,41 @@
+import {
+  IconClock,
+  IconExclamationCircle,
+  IconLoader4,
+} from '@tabler/icons-react';
+
+import {
+  PREPROCESSING_STATUS_LABEL,
+  PreprocessingStatus,
+} from '@/src/models/preprocessing-status';
+import { CheckIcon } from '@/src/components/GridView/StatusIconCell/CheckIcon';
+import { StatusVisual } from '@/src/components/GridView/StatusIconCell/types';
+
+export const PREPROCESSING_STATUS_VISUALS: Record<
+  PreprocessingStatus,
+  StatusVisual
+> = {
+  [PreprocessingStatus.NOT_STARTED]: {
+    label: PREPROCESSING_STATUS_LABEL[PreprocessingStatus.NOT_STARTED],
+  },
+  [PreprocessingStatus.QUEUED]: {
+    label: PREPROCESSING_STATUS_LABEL[PreprocessingStatus.QUEUED],
+    icon: IconClock,
+    iconColorClass: 'text-icon-secondary',
+  },
+  [PreprocessingStatus.IN_PROGRESS]: {
+    label: PREPROCESSING_STATUS_LABEL[PreprocessingStatus.IN_PROGRESS],
+    icon: IconLoader4,
+    iconColorClass: 'text-icon-accent-primary',
+  },
+  [PreprocessingStatus.COMPLETED]: {
+    label: PREPROCESSING_STATUS_LABEL[PreprocessingStatus.COMPLETED],
+    icon: CheckIcon,
+  },
+  [PreprocessingStatus.FAILED]: {
+    label: PREPROCESSING_STATUS_LABEL[PreprocessingStatus.FAILED],
+    icon: IconExclamationCircle,
+    iconColorClass: 'text-icon-error',
+    textColorClass: 'text-error',
+  },
+};

--- a/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/CheckIcon.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/CheckIcon.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import Check from '@/public/icons/check.svg';
+import { mergeClasses } from '@/src/utils/mergeClasses';
+import { StatusIconProps } from './types';
+
+export const CheckIcon = ({ className }: StatusIconProps) => (
+  <Check
+    className={mergeClasses(
+      '[&_path]:fill-[var(--icon-accent-secondary,#37BABC)] size-4',
+      className,
+    )}
+  />
+);

--- a/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/StatusIcon.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/StatusIcon.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { mergeClasses } from '@/src/utils/mergeClasses';
+import { StatusIconProps } from './types';
+import { ComponentType } from 'react';
+import { Tooltip } from '@/src/components/BaseComponents/Tooltip/Tooltip';
+
+interface Props {
+  icon?: ComponentType<StatusIconProps>;
+  colorClass?: string;
+  tooltipContent?: string;
+}
+
+export const StatusIcon = ({
+  icon: Icon,
+  colorClass,
+  tooltipContent,
+}: Props) => {
+  if (!Icon) return null;
+
+  const iconEl = (
+    <Icon
+      size={16}
+      className={mergeClasses(
+        'flex-shrink-0 ml-auto',
+        colorClass,
+        tooltipContent && 'cursor-help',
+      )}
+    />
+  );
+
+  return tooltipContent ? (
+    <Tooltip content={tooltipContent} className="ml-auto flex-shrink-0">
+      {iconEl}
+    </Tooltip>
+  ) : (
+    iconEl
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/StatusIconCell.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/StatusIconCell.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { ICellRendererParams } from 'ag-grid-community';
+
+import { mergeClasses } from '@/src/utils/mergeClasses';
+import { StatusIcon } from './StatusIcon';
+import { StatusVisual } from './types';
+
+interface Props<TData> extends ICellRendererParams<TData> {
+  config: Record<string, StatusVisual>;
+  tooltip?: (data: TData | undefined) => string | undefined;
+}
+
+export const StatusIconCell = <TData,>({
+  value,
+  data,
+  config,
+  tooltip,
+}: Props<TData>) => {
+  if (value == null || value === '') return null;
+
+  const visual = config[String(value)];
+  const label = visual?.label ?? String(value);
+
+  return (
+    <div
+      className={mergeClasses(
+        'flex items-center w-full',
+        visual?.textColorClass,
+      )}
+    >
+      <span>{label}</span>
+      <StatusIcon
+        icon={visual?.icon}
+        colorClass={visual?.iconColorClass}
+        tooltipContent={tooltip?.(data)}
+      />
+    </div>
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/types.ts
+++ b/apps/statgpt-admin-frontend/src/components/GridView/StatusIconCell/types.ts
@@ -1,0 +1,13 @@
+import { ComponentType } from 'react';
+
+export interface StatusIconProps {
+  size?: number;
+  className?: string;
+}
+
+export interface StatusVisual {
+  label: string;
+  icon?: ComponentType<StatusIconProps>;
+  iconColorClass?: string;
+  textColorClass?: string;
+}

--- a/apps/statgpt-admin-frontend/src/components/GridView/ValidationStatusCell/ValidationStatusCell.tsx
+++ b/apps/statgpt-admin-frontend/src/components/GridView/ValidationStatusCell/ValidationStatusCell.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ICellRendererParams } from 'ag-grid-community';
+
+import {
+  DiscoveryDataset,
+  formatDiscoveryValidationIssues,
+} from '@/src/models/discovery-dataset';
+import { StatusIconCell } from '@/src/components/GridView/StatusIconCell/StatusIconCell';
+import { DISCOVERY_VALIDATION_STATUS_VISUALS } from './discovery-validation-status-visuals';
+
+export const ValidationStatusCell = (
+  params: ICellRendererParams<DiscoveryDataset>,
+) => (
+  <StatusIconCell
+    {...params}
+    config={DISCOVERY_VALIDATION_STATUS_VISUALS}
+    tooltip={(data) => formatDiscoveryValidationIssues(data?.validationIssues)}
+  />
+);

--- a/apps/statgpt-admin-frontend/src/components/GridView/ValidationStatusCell/discovery-validation-status-visuals.ts
+++ b/apps/statgpt-admin-frontend/src/components/GridView/ValidationStatusCell/discovery-validation-status-visuals.ts
@@ -1,0 +1,30 @@
+import { IconClock, IconExclamationCircle } from '@tabler/icons-react';
+
+import {
+  DISCOVERY_VALIDATION_STATUS_LABEL,
+  DiscoveryValidationStatus,
+} from '@/src/models/discovery-dataset';
+import { CheckIcon } from '@/src/components/GridView/StatusIconCell/CheckIcon';
+import { StatusVisual } from '@/src/components/GridView/StatusIconCell/types';
+
+export const DISCOVERY_VALIDATION_STATUS_VISUALS: Record<
+  DiscoveryValidationStatus,
+  StatusVisual
+> = {
+  [DiscoveryValidationStatus.NotValidated]: {
+    label:
+      DISCOVERY_VALIDATION_STATUS_LABEL[DiscoveryValidationStatus.NotValidated],
+    icon: IconClock,
+    iconColorClass: 'text-icon-secondary',
+  },
+  [DiscoveryValidationStatus.Valid]: {
+    label: DISCOVERY_VALIDATION_STATUS_LABEL[DiscoveryValidationStatus.Valid],
+    icon: CheckIcon,
+  },
+  [DiscoveryValidationStatus.Invalid]: {
+    label: DISCOVERY_VALIDATION_STATUS_LABEL[DiscoveryValidationStatus.Invalid],
+    icon: IconExclamationCircle,
+    iconColorClass: 'text-icon-error',
+    textColorClass: 'text-error',
+  },
+};

--- a/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
@@ -1,20 +1,50 @@
 export enum DiscoveryValidationStatus {
-  Pending = 'pending',
-  Valid = 'valid',
-  Invalid = 'invalid',
+  NotValidated = 'NOT_VALIDATED',
+  Valid = 'VALID',
+  Invalid = 'INVALID',
 }
 
+export const DISCOVERY_VALIDATION_STATUS_LABEL: Record<
+  DiscoveryValidationStatus,
+  string
+> = {
+  [DiscoveryValidationStatus.NotValidated]: 'Not validated',
+  [DiscoveryValidationStatus.Valid]: 'Valid',
+  [DiscoveryValidationStatus.Invalid]: 'Invalid',
+};
+
 export enum DiscoveryIndexingStatus {
-  Pending = 'pending',
-  Indexing = 'indexing',
-  Indexed = 'indexed',
-  Failed = 'failed',
+  New = 'NEW',
+  Outdated = 'OUTDATED',
+  Indexed = 'INDEXED',
+  Failed = 'FAILED',
 }
+
+export const DISCOVERY_INDEXING_STATUS_LABEL: Record<
+  DiscoveryIndexingStatus,
+  string
+> = {
+  [DiscoveryIndexingStatus.New]: 'New',
+  [DiscoveryIndexingStatus.Outdated]: 'Outdated',
+  [DiscoveryIndexingStatus.Indexed]: 'Indexed',
+  [DiscoveryIndexingStatus.Failed]: 'Failed',
+};
 
 export interface DiscoveryValidationIssue {
   field?: string;
   message?: string;
 }
+
+export const formatDiscoveryValidationIssues = (
+  issues?: DiscoveryValidationIssue[] | null,
+): string => {
+  if (!issues || !issues.length) return '';
+  return issues
+    .map((issue) =>
+      issue.field ? `${issue.field}: ${issue.message}` : issue.message,
+    )
+    .join('; ');
+};
 
 export interface DiscoveryDataset {
   id: number;

--- a/apps/statgpt-admin-frontend/tailwind.config.js
+++ b/apps/statgpt-admin-frontend/tailwind.config.js
@@ -66,6 +66,7 @@ const buttonsTextColors = {
 
 const iconColors = {
   'icon-error': 'var(--icon-error, #F76464)',
+  'icon-warning': 'var(--icon-warning, #EEC840)',
   'icon-accent-secondary': 'var(--icon-accent-secondary, #37BABC)',
   'icon-secondary': 'var(--icon-secondary, #7F8792)',
   'icon-primary': 'var(--icon-secondary, #F3F4F6)',


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Adds "Validation Status" and "Indexing Status" columns to the Discovery Datasets grid, each showing a label + status icon (check/clock/warning/exclamation) with a tooltip for extra detail (validation issues / index error) on failure/warning states.

Extracted a generic, reusable `StatusIconCell`/`StatusIcon` component (`src/components/GridView/StatusIconCell/`) driven by a per-status config map, and migrated the existing `PreprocessingStatusCell`/`PreprocessingStatusIcon` onto it (same visuals, no behavior change) so all three status columns share one implementation.

Also fixes the two status enums to match the backend's real values, syncs the details modal's labels with the grid, and drops the "Description" column (still in the popup).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.