### PR TITLE
feat: add reindex action to discovery datasets page

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/channels/actions.ts
+++ b/apps/statgpt-admin-frontend/src/app/channels/actions.ts
@@ -5,7 +5,13 @@ import { cookies, headers } from 'next/headers';
 import { channelsApi } from '@/src/app/api/api';
 import { Channel, ChannelTerm } from '@/src/models/channel';
 import type { DeduplicationJob } from '@/src/models/deduplication-job';
+import {
+  DiscoveryIndexingJobStatus,
+  type DiscoveryIndexingJob,
+} from '@/src/models/discovery-dataset';
+import type { RequestData } from '@/src/models/request-data';
 import type { ApiResult } from '@/src/server/api';
+import { logger } from '@/src/server/logger';
 import { getUserToken } from '@/src/utils/auth/get-token';
 import { getIsEnableAuthToggle } from '@/src/utils/get-auth-toggle';
 
@@ -162,4 +168,54 @@ export async function getChannelIndexStatus(id: string) {
     cookies(),
   );
   return channelsApi.getChannelIndexStatus(id, token);
+}
+
+const logIfFailed = (job: DiscoveryIndexingJob) => {
+  if (job.status === DiscoveryIndexingJobStatus.Failed) {
+    logger.error(
+      `Discovery indexing job ${job.id} for channel ${job.channelId} failed: ${job.reasonForFailure}`,
+    );
+  }
+};
+
+export async function triggerDiscoveryIndexingJob(
+  id: string,
+  force: boolean,
+): Promise<ApiResult<DiscoveryIndexingJob>> {
+  const token = await getUserToken(
+    getIsEnableAuthToggle(),
+    headers(),
+    cookies(),
+  );
+  const result = await channelsApi.triggerDiscoveryIndexingJob(
+    id,
+    force,
+    token,
+  );
+  if (result.ok) logIfFailed(result.data);
+  return result;
+}
+
+export async function getLatestDiscoveryIndexingJob(
+  id: string,
+): Promise<ApiResult<RequestData<DiscoveryIndexingJob>>> {
+  const token = await getUserToken(
+    getIsEnableAuthToggle(),
+    headers(),
+    cookies(),
+  );
+  return channelsApi.listDiscoveryIndexingJobs(id, 1, 0, token);
+}
+
+export async function getDiscoveryIndexingJob(
+  jobId: string | number,
+): Promise<ApiResult<DiscoveryIndexingJob>> {
+  const token = await getUserToken(
+    getIsEnableAuthToggle(),
+    headers(),
+    cookies(),
+  );
+  const result = await channelsApi.getDiscoveryIndexingJob(jobId, token);
+  if (result.ok) logIfFailed(result.data);
+  return result;
 }

--- a/apps/statgpt-admin-frontend/src/components/BaseComponents/ConfirmDialog/ConfirmDialog.tsx
+++ b/apps/statgpt-admin-frontend/src/components/BaseComponents/ConfirmDialog/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef } from 'react';
+import { ReactNode, useId, useRef } from 'react';
 
 import Modal from '@/src/components/Modal/ModalView';
 import { PopUpState } from '@/src/types/modal';
@@ -10,6 +10,8 @@ interface Props {
   confirmLabel: string;
   cancelLabel?: string | null;
   headerClassName?: string;
+  /** Extra content rendered between the description and the action buttons. */
+  children?: ReactNode;
   onClose: (result: boolean) => void;
 }
 
@@ -20,6 +22,7 @@ export const ConfirmDialog = ({
   confirmLabel,
   cancelLabel,
   modalState,
+  children,
   onClose,
 }: Props) => {
   const confirmLabelRef = useRef<HTMLButtonElement>(null);
@@ -38,18 +41,19 @@ export const ConfirmDialog = ({
       headerClassName={headerClassName}
     >
       <div className="flex flex-col justify-between gap-4">
-        <div className="flex w-full flex-col gap-2 text-start">
+        <div className="flex w-full flex-col gap-4 text-start">
           <div>
             {description && (
               <p
                 id={descriptionId}
                 data-qa="confirm-message"
-                className="whitespace-pre-wrap text-secondary"
+                className="whitespace-pre-wrap text-sm text-secondary"
               >
                 {description}
               </p>
             )}
           </div>
+          {children}
         </div>
         <div className="flex w-full items-center justify-end gap-3">
           {cancelLabel && (

--- a/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/components/ChannelView/Datasets/useDeduplicationJobPolling.ts
@@ -1,21 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 
 import {
   deduplicateDataset,
   getDeduplicationJob,
 } from '@/src/app/channels/actions';
-import { useNotification } from '@/src/context/NotificationContext';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useJobPolling } from '@/src/hooks/useJobPolling';
 import {
   DeduplicationJobStatus,
   type DeduplicationJob,
 } from '@/src/models/deduplication-job';
-import { NotificationType } from '@/src/models/notification';
-
-const DEDUPLICATION_JOB_POLL_INTERVAL_MS = 5000;
-const DEDUPLICATION_JOB_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+import { Notification, NotificationType } from '@/src/models/notification';
 
 const DEDUPLICATION_JOB_STATUS_TITLE: Record<DeduplicationJobStatus, string> = {
   [DeduplicationJobStatus.NOT_STARTED]: 'Duplicate removal not started',
@@ -47,6 +44,37 @@ const getDeduplicationSuccessDescription = (job: DeduplicationJob) =>
     `Special deleted: ${job.special_deleted}`,
   ].join('\n');
 
+const isDeduplicationJobFinal = (job: DeduplicationJob) =>
+  job.status === DeduplicationJobStatus.COMPLETED ||
+  job.status === DeduplicationJobStatus.FAILED;
+
+const deduplicationJobStatusKey = (job: DeduplicationJob) => job.status;
+
+const buildDeduplicationStatusNotification = (job: DeduplicationJob) => ({
+  title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
+  description: DEDUPLICATION_JOB_STATUS_DESCRIPTION[job.status],
+});
+
+const buildDeduplicationFinalNotification = (
+  job: DeduplicationJob,
+): Notification => {
+  if (job.status === DeduplicationJobStatus.FAILED) {
+    return {
+      type: NotificationType.error,
+      title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
+      description:
+        job.reason_for_failure?.trim() ||
+        'Unable to remove duplicates. Please try again.',
+    };
+  }
+
+  return {
+    type: NotificationType.success,
+    title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
+    description: getDeduplicationSuccessDescription(job),
+  };
+};
+
 interface UseDeduplicationJobPollingParams {
   channelId?: string;
   onFinished: () => void;
@@ -56,180 +84,23 @@ export const useDeduplicationJobPolling = ({
   channelId,
   onFinished,
 }: UseDeduplicationJobPollingParams) => {
-  const { showNotification, removeNotification } = useNotification();
   const withNotification = useApiNotification();
 
-  const [isDeduplicationInProgress, setIsDeduplicationInProgress] =
-    useState(false);
+  const { isInProgress, operationIdRef, resetState, invalidate, startPolling } =
+    useJobPolling<DeduplicationJob>({
+      isFinal: isDeduplicationJobFinal,
+      statusKey: deduplicationJobStatusKey,
+      buildStatusNotification: buildDeduplicationStatusNotification,
+      buildFinalNotification: buildDeduplicationFinalNotification,
+      pollFn: getDeduplicationJob,
+      onFinal: () => onFinished(),
+      pollErrorTitle: 'Deduplication status check failed',
+      timeoutTitle: 'Deduplication is taking longer than expected',
+      timeoutDescription:
+        'Duplicate removal is still running in the background. Please check back later.',
+    });
 
-  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pollingStartedAtRef = useRef<number | null>(null);
-  const notificationIdRef = useRef<string | null>(null);
-  const lastStatusRef = useRef<DeduplicationJobStatus | null>(null);
-  const operationIdRef = useRef(0);
-  const showNotificationRef = useRef(showNotification);
-  const removeNotificationRef = useRef(removeNotification);
-  const onFinishedRef = useRef(onFinished);
-
-  showNotificationRef.current = showNotification;
-  removeNotificationRef.current = removeNotification;
-  onFinishedRef.current = onFinished;
-
-  const clearPolling = useCallback(() => {
-    if (pollingTimeoutRef.current != null) {
-      clearTimeout(pollingTimeoutRef.current);
-      pollingTimeoutRef.current = null;
-    }
-  }, []);
-
-  const clearNotification = useCallback(() => {
-    if (notificationIdRef.current != null) {
-      removeNotificationRef.current(notificationIdRef.current);
-      notificationIdRef.current = null;
-    }
-  }, []);
-
-  const replaceNotification = useCallback(
-    (notification: Parameters<typeof showNotification>[0]) => {
-      clearNotification();
-      notificationIdRef.current = showNotificationRef.current(notification);
-    },
-    [clearNotification],
-  );
-
-  const resetState = useCallback(
-    (inProgress: boolean) => {
-      clearPolling();
-      clearNotification();
-      lastStatusRef.current = null;
-      operationIdRef.current += 1;
-      setIsDeduplicationInProgress(inProgress);
-    },
-    [clearNotification, clearPolling],
-  );
-
-  const showStatusNotification = useCallback(
-    (job: DeduplicationJob) => {
-      if (
-        notificationIdRef.current != null &&
-        lastStatusRef.current === job.status
-      ) {
-        return;
-      }
-
-      lastStatusRef.current = job.status;
-      replaceNotification({
-        type: NotificationType.loading,
-        title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
-        description: DEDUPLICATION_JOB_STATUS_DESCRIPTION[job.status],
-        duration: null,
-        onClose: () => {
-          notificationIdRef.current = null;
-          lastStatusRef.current = null;
-        },
-      });
-    },
-    [replaceNotification],
-  );
-
-  const showFinalNotification = useCallback(
-    (job: DeduplicationJob) => {
-      resetState(false);
-      onFinishedRef.current();
-
-      if (job.status === DeduplicationJobStatus.FAILED) {
-        showNotificationRef.current({
-          type: NotificationType.error,
-          title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
-          description:
-            job.reason_for_failure?.trim() ||
-            'Unable to remove duplicates. Please try again.',
-        });
-        return;
-      }
-
-      showNotificationRef.current({
-        type: NotificationType.success,
-        title: DEDUPLICATION_JOB_STATUS_TITLE[job.status],
-        description: getDeduplicationSuccessDescription(job),
-      });
-    },
-    [resetState],
-  );
-
-  const handleJob = useCallback(
-    (job: DeduplicationJob) => {
-      if (
-        job.status === DeduplicationJobStatus.COMPLETED ||
-        job.status === DeduplicationJobStatus.FAILED
-      ) {
-        showFinalNotification(job);
-        return true;
-      }
-
-      showStatusNotification(job);
-      return false;
-    },
-    [showFinalNotification, showStatusNotification],
-  );
-
-  const startPolling = useCallback(
-    (jobId: number, operationId: number) => {
-      clearPolling();
-      pollingStartedAtRef.current = Date.now();
-
-      const poll = async () => {
-        const result = await getDeduplicationJob(jobId);
-        if (operationIdRef.current !== operationId) {
-          return;
-        }
-
-        if (!result.ok) {
-          resetState(false);
-          showNotificationRef.current({
-            type: NotificationType.error,
-            title: 'Deduplication status check failed',
-            description:
-              result.error.message ||
-              'Unable to check deduplication status. Please try again.',
-          });
-          return;
-        }
-
-        if (handleJob(result.data)) {
-          return;
-        }
-
-        const elapsed =
-          pollingStartedAtRef.current != null
-            ? Date.now() - pollingStartedAtRef.current
-            : 0;
-        if (elapsed >= DEDUPLICATION_JOB_POLL_TIMEOUT_MS) {
-          resetState(false);
-          showNotificationRef.current({
-            type: NotificationType.error,
-            title: 'Deduplication is taking longer than expected',
-            description:
-              'Duplicate removal is still running in the background. Please check back later.',
-          });
-          return;
-        }
-
-        pollingTimeoutRef.current = setTimeout(
-          poll,
-          DEDUPLICATION_JOB_POLL_INTERVAL_MS,
-        );
-      };
-
-      pollingTimeoutRef.current = setTimeout(
-        poll,
-        DEDUPLICATION_JOB_POLL_INTERVAL_MS,
-      );
-    },
-    [clearPolling, handleJob, resetState],
-  );
-
-  const deduplicate = useCallback(() => {
+  const deduplicate = () => {
     if (channelId == null) {
       return;
     }
@@ -246,27 +117,22 @@ export const useDeduplicationJobPolling = ({
       }
 
       if (result.ok) {
-        if (!handleJob(result.data)) {
-          startPolling(result.data.id, operationId);
-        }
+        startPolling(result.data.id, operationId, result.data);
       } else {
-        setIsDeduplicationInProgress(false);
+        resetState(false);
       }
     });
-  }, [channelId, resetState, handleJob, startPolling, withNotification]);
+  };
 
   useEffect(() => {
     resetState(false);
     return () => {
-      clearPolling();
-      clearNotification();
-      lastStatusRef.current = null;
-      operationIdRef.current += 1;
+      invalidate();
     };
-  }, [channelId, resetState, clearPolling, clearNotification]);
+  }, [channelId, resetState, invalidate]);
 
   return {
     deduplicate,
-    isDeduplicationInProgress,
+    isDeduplicationInProgress: isInProgress,
   };
 };

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useCallback, useState } from 'react';
 import { ColDef } from 'ag-grid-community';
-import { IconFileArrowLeft } from '@tabler/icons-react';
+import { IconFileArrowLeft, IconRefreshDot } from '@tabler/icons-react';
 import { createPortal } from 'react-dom';
 
 import { useAccessControl } from '@/src/context/AccessControlContext';
@@ -19,10 +19,13 @@ import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { DiscoveryDataset } from '@/src/models/discovery-dataset';
 import { RequestData } from '@/src/models/request-data';
 import { sendGetRequest } from '@/src/server/api';
+import { PopUpState } from '@/src/types/modal';
 import { ValidationStatusCell } from '@/src/components/GridView/ValidationStatusCell/ValidationStatusCell';
 import { IndexingStatusCell } from '@/src/components/GridView/IndexingStatusCell/IndexingStatusCell';
 import { DiscoveryDatasetActionColumn } from './ActionColumn/ActionColumn';
 import { UploadModal } from './UploadModal/UploadModal';
+import { ReindexConfirmDialog } from './ReindexConfirmDialog/ReindexConfirmDialog';
+import { useDiscoveryIndexingJobPolling } from './useDiscoveryIndexingJobPolling';
 
 interface Props {
   selectedChannelId: string;
@@ -60,8 +63,15 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   const withNotification = useApiNotification();
   const [refreshToken, setRefreshToken] = useState(0);
   const [showUploadModal, setShowUploadModal] = useState(false);
+  const [showReindexConfirm, setShowReindexConfirm] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   usePageInitialLoadingSync(isInitialLoading);
+
+  const { triggerReindex, isReindexInProgress } =
+    useDiscoveryIndexingJobPolling({
+      channelId: selectedChannelId,
+      onCompleted: () => setRefreshToken((x) => x + 1),
+    });
 
   const fetchRows = useCallback(
     async (args: FetchRowsArgs): Promise<FetchRowsResult<DiscoveryDataset>> => {
@@ -91,12 +101,21 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
     <div className="bg-layer-2 flex flex-col h-full common-paddings">
       <div className="flex flex-row items-center justify-between mb-3">
         <h1 className="mb-4">Discovery Datasets</h1>
-        <Button
-          cssClass="primary ml-3"
-          title="Upload"
-          icon={<IconFileArrowLeft {...BASE_ICON_PROPS} />}
-          onClick={() => setShowUploadModal(true)}
-        />
+        <div className="flex flex-row items-center">
+          <Button
+            cssClass="secondary"
+            title="Reindex"
+            icon={<IconRefreshDot {...BASE_ICON_PROPS} />}
+            disable={isReindexInProgress}
+            onClick={() => setShowReindexConfirm(true)}
+          />
+          <Button
+            cssClass="primary ml-3"
+            title="Upload"
+            icon={<IconFileArrowLeft {...BASE_ICON_PROPS} />}
+            onClick={() => setShowUploadModal(true)}
+          />
+        </div>
       </div>
       <div className="flex-1 min-h-0">
         <GridView<DiscoveryDataset>
@@ -116,6 +135,13 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
           />,
           document.body,
         )}
+      <ReindexConfirmDialog
+        modalState={showReindexConfirm ? PopUpState.Opened : PopUpState.Closed}
+        onClose={({ confirmed, force }) => {
+          setShowReindexConfirm(false);
+          if (confirmed) triggerReindex(force);
+        }}
+      />
     </div>
   );
 };

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/ReindexConfirmDialog/ReindexConfirmDialog.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/ReindexConfirmDialog/ReindexConfirmDialog.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+
+import Checkbox from '@/src/components/BaseComponents/Checkbox/Checkbox';
+import { ConfirmDialog } from '@/src/components/BaseComponents/ConfirmDialog/ConfirmDialog';
+import { PopUpState } from '@/src/types/modal';
+
+interface Props {
+  modalState: PopUpState;
+  onClose: (result: { confirmed: boolean; force: boolean }) => void;
+}
+
+export const ReindexConfirmDialog = ({ modalState, onClose }: Props) => {
+  const [force, setForce] = useState(false);
+  const [prevModalState, setPrevModalState] = useState(modalState);
+
+  if (modalState !== prevModalState) {
+    setPrevModalState(modalState);
+    if (modalState === PopUpState.Opened) {
+      setForce(false);
+    }
+  }
+
+  return (
+    <ConfirmDialog
+      modalState={modalState}
+      header="Confirm discovery datasets reindexing"
+      description="Reindexing will re-validate all discovery dataset records and republish them to the knowledge base. This may be time-consuming."
+      confirmLabel="Reindex"
+      cancelLabel="Cancel"
+      onClose={(confirmed) => onClose({ confirmed, force })}
+    >
+      <div className="flex flex-col gap-2">
+        <Checkbox
+          id="reindex-force"
+          label="Force full reindex"
+          checked={force}
+          onChange={(value) => setForce(!!value)}
+        />
+        <p className="whitespace-pre-wrap text-sm text-secondary">
+          Force reindex will republish every valid record from scratch, even if
+          unchanged.
+        </p>
+      </div>
+    </ConfirmDialog>
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
@@ -90,7 +90,9 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
 
         {step === 'success' && summary && (
           <div className="flex flex-col gap-y-2">
-            <p className="text-primary">Upload completed successfully.</p>
+            <p className="text-sm text-primary">
+              Upload completed successfully.
+            </p>
             <table className="w-full text-sm">
               <tbody>
                 {SUMMARY_LABELS.map(({ key, label }) => (
@@ -108,7 +110,7 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
 
         {step === 'error' && (
           <div className="flex flex-col gap-y-2">
-            <p className="text-error">{errorMessage}</p>
+            <p className="text-sm text-error">{errorMessage}</p>
             {problems.length > 0 && (
               <div className="overflow-auto max-h-[300px]">
                 <table className="w-full text-sm">

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/useDiscoveryIndexingJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/useDiscoveryIndexingJobPolling.ts
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import {
+  getDiscoveryIndexingJob,
+  getLatestDiscoveryIndexingJob,
+  triggerDiscoveryIndexingJob,
+} from '@/src/app/channels/actions';
+import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useJobPolling } from '@/src/hooks/useJobPolling';
+import {
+  DiscoveryIndexingJobStatus,
+  type DiscoveryIndexingJob,
+} from '@/src/models/discovery-dataset';
+import { Notification, NotificationType } from '@/src/models/notification';
+
+const DISCOVERY_INDEXING_JOB_STATUS_TITLE: Record<
+  DiscoveryIndexingJobStatus,
+  string
+> = {
+  [DiscoveryIndexingJobStatus.Queued]: 'Reindexing queued',
+  [DiscoveryIndexingJobStatus.InProgress]: 'Reindexing in progress',
+  [DiscoveryIndexingJobStatus.Completed]: 'Reindexing completed',
+  [DiscoveryIndexingJobStatus.Failed]: 'Reindexing failed',
+};
+
+const DISCOVERY_INDEXING_JOB_STATUS_DESCRIPTION: Record<
+  DiscoveryIndexingJobStatus,
+  string
+> = {
+  [DiscoveryIndexingJobStatus.Queued]:
+    'Your request is in the queue and will start shortly.',
+  [DiscoveryIndexingJobStatus.InProgress]:
+    'Validating records and publishing to the knowledge base — you can keep working in the meantime.',
+  [DiscoveryIndexingJobStatus.Completed]: 'Reindexing completed.',
+  [DiscoveryIndexingJobStatus.Failed]: 'Reindexing failed.',
+};
+
+const getDiscoveryIndexingSuccessDescription = (job: DiscoveryIndexingJob) =>
+  [
+    `Records valid: ${job.recordsValid}`,
+    `Records invalid: ${job.recordsInvalid}`,
+    `Documents upserted: ${job.documentsUpserted}`,
+    `Documents deleted: ${job.documentsDeleted}`,
+  ].join('\n');
+
+const isDiscoveryIndexingJobFinal = (job: DiscoveryIndexingJob) =>
+  job.status === DiscoveryIndexingJobStatus.Completed ||
+  job.status === DiscoveryIndexingJobStatus.Failed;
+
+const discoveryIndexingJobStatusKey = (job: DiscoveryIndexingJob) => job.status;
+
+const buildDiscoveryStatusNotification = (job: DiscoveryIndexingJob) => ({
+  title: DISCOVERY_INDEXING_JOB_STATUS_TITLE[job.status],
+  description: DISCOVERY_INDEXING_JOB_STATUS_DESCRIPTION[job.status],
+});
+
+const buildDiscoveryFinalNotification = (
+  job: DiscoveryIndexingJob,
+): Notification => {
+  if (job.status === DiscoveryIndexingJobStatus.Failed) {
+    return {
+      type: NotificationType.error,
+      title: DISCOVERY_INDEXING_JOB_STATUS_TITLE[job.status],
+      description:
+        job.reasonForFailure?.trim() ||
+        'Unable to reindex discovery datasets. Please try again.',
+    };
+  }
+
+  return {
+    type: NotificationType.success,
+    title: DISCOVERY_INDEXING_JOB_STATUS_TITLE[job.status],
+    description: getDiscoveryIndexingSuccessDescription(job),
+  };
+};
+
+interface UseDiscoveryIndexingJobPollingParams {
+  channelId?: string;
+  onCompleted: () => void;
+}
+
+export const useDiscoveryIndexingJobPolling = ({
+  channelId,
+  onCompleted,
+}: UseDiscoveryIndexingJobPollingParams) => {
+  const withNotification = useApiNotification();
+
+  const { isInProgress, operationIdRef, resetState, invalidate, startPolling } =
+    useJobPolling<DiscoveryIndexingJob>({
+      isFinal: isDiscoveryIndexingJobFinal,
+      statusKey: discoveryIndexingJobStatusKey,
+      buildStatusNotification: buildDiscoveryStatusNotification,
+      buildFinalNotification: buildDiscoveryFinalNotification,
+      pollFn: getDiscoveryIndexingJob,
+      onFinal: (job) => {
+        if (job.status === DiscoveryIndexingJobStatus.Failed) {
+          console.error(
+            `Discovery indexing job ${job.id} for channel ${job.channelId} failed: ${job.reasonForFailure}`,
+          );
+        }
+        onCompleted();
+      },
+      pollErrorTitle: 'Reindex status check failed',
+      timeoutTitle: 'Reindexing is taking longer than expected',
+      timeoutDescription:
+        'Reindexing is still running in the background. Please check back later.',
+    });
+
+  const triggerReindex = (force: boolean) => {
+    if (channelId == null) {
+      return;
+    }
+
+    resetState(true);
+    const operationId = operationIdRef.current;
+
+    withNotification(
+      triggerDiscoveryIndexingJob(channelId, force),
+      'Reindex Failed',
+    ).then((result) => {
+      if (operationIdRef.current !== operationId) {
+        return;
+      }
+
+      if (result.ok) {
+        startPolling(result.data.id, operationId, result.data);
+      } else {
+        resetState(false);
+      }
+    });
+  };
+
+  useEffect(() => {
+    resetState(false);
+
+    if (channelId == null) {
+      return;
+    }
+
+    const operationId = operationIdRef.current;
+
+    getLatestDiscoveryIndexingJob(channelId).then((result) => {
+      if (operationIdRef.current !== operationId || !result.ok) {
+        return;
+      }
+
+      const [latestJob] = result.data.data;
+      if (latestJob && !isDiscoveryIndexingJobFinal(latestJob)) {
+        startPolling(latestJob.id, operationId, latestJob);
+      }
+    });
+
+    return () => {
+      invalidate();
+    };
+  }, [channelId, resetState, invalidate, operationIdRef, startPolling]);
+
+  return {
+    triggerReindex,
+    isReindexInProgress: isInProgress,
+  };
+};

--- a/apps/statgpt-admin-frontend/src/hooks/useJobPolling.ts
+++ b/apps/statgpt-admin-frontend/src/hooks/useJobPolling.ts
@@ -1,0 +1,223 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import { useNotification } from '@/src/context/NotificationContext';
+import { Notification, NotificationType } from '@/src/models/notification';
+import { ApiResult } from '@/src/server/api';
+
+export interface UseJobPollingParams<TJob> {
+  /** Whether the job has reached a terminal (completed/failed) state. */
+  isFinal: (job: TJob) => boolean;
+  /** Value used to avoid replacing the loading toast when polling returns the same status. */
+  statusKey: (job: TJob) => string | number;
+  /** Loading toast shown while the job is still running. */
+  buildStatusNotification: (
+    job: TJob,
+  ) => Pick<Notification, 'title' | 'description'>;
+  /** Toast shown once the job reaches a terminal state. */
+  buildFinalNotification: (job: TJob) => Notification;
+  /** Fetches the current state of a job by id, for polling. */
+  pollFn: (jobId: number) => Promise<ApiResult<TJob>>;
+  /** Called once, right before the final toast is shown, for both success and failure. */
+  onFinal: (job: TJob) => void;
+  pollErrorTitle: string;
+  timeoutTitle: string;
+  timeoutDescription: string;
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+/**
+ * Polls a background job until it reaches a terminal state, showing a persistent loading
+ * toast that is replaced by a success/error toast on completion. Shared by every "trigger a
+ * job, then poll it" flow (deduplication, discovery datasets reindexing, ...) so the
+ * polling/notification bookkeeping - timers, stale-response guarding, toast lifecycle - lives
+ * in one place.
+ */
+export function useJobPolling<TJob>({
+  isFinal,
+  statusKey,
+  buildStatusNotification,
+  buildFinalNotification,
+  pollFn,
+  onFinal,
+  pollErrorTitle,
+  timeoutTitle,
+  timeoutDescription,
+  intervalMs = 5000,
+  timeoutMs = 5 * 60 * 1000,
+}: UseJobPollingParams<TJob>) {
+  const { showNotification, removeNotification } = useNotification();
+
+  const [isInProgress, setIsInProgress] = useState(false);
+
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollingStartedAtRef = useRef<number | null>(null);
+  const notificationIdRef = useRef<string | null>(null);
+  const lastStatusKeyRef = useRef<string | number | null>(null);
+  const operationIdRef = useRef(0);
+  const showNotificationRef = useRef(showNotification);
+  const removeNotificationRef = useRef(removeNotification);
+  const onFinalRef = useRef(onFinal);
+
+  showNotificationRef.current = showNotification;
+  removeNotificationRef.current = removeNotification;
+  onFinalRef.current = onFinal;
+
+  const clearPolling = useCallback(() => {
+    if (pollingTimeoutRef.current != null) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearNotification = useCallback(() => {
+    if (notificationIdRef.current != null) {
+      removeNotificationRef.current(notificationIdRef.current);
+      notificationIdRef.current = null;
+    }
+  }, []);
+
+  const replaceNotification = useCallback(
+    (notification: Notification) => {
+      clearNotification();
+      notificationIdRef.current = showNotificationRef.current(notification);
+    },
+    [clearNotification],
+  );
+
+  const invalidate = useCallback(() => {
+    clearPolling();
+    clearNotification();
+    lastStatusKeyRef.current = null;
+    operationIdRef.current += 1;
+  }, [clearNotification, clearPolling]);
+
+  const resetState = useCallback(
+    (inProgress: boolean) => {
+      invalidate();
+      setIsInProgress(inProgress);
+    },
+    [invalidate],
+  );
+
+  const showStatusNotification = useCallback(
+    (job: TJob) => {
+      const key = statusKey(job);
+      if (
+        notificationIdRef.current != null &&
+        lastStatusKeyRef.current === key
+      ) {
+        return;
+      }
+
+      lastStatusKeyRef.current = key;
+      replaceNotification({
+        type: NotificationType.loading,
+        ...buildStatusNotification(job),
+        duration: null,
+        onClose: () => {
+          notificationIdRef.current = null;
+          lastStatusKeyRef.current = null;
+        },
+      });
+    },
+    [replaceNotification, statusKey, buildStatusNotification],
+  );
+
+  const showFinal = useCallback(
+    (job: TJob) => {
+      resetState(false);
+      onFinalRef.current(job);
+      showNotificationRef.current(buildFinalNotification(job));
+    },
+    [resetState, buildFinalNotification],
+  );
+
+  const handleJob = useCallback(
+    (job: TJob) => {
+      if (isFinal(job)) {
+        showFinal(job);
+        return true;
+      }
+
+      showStatusNotification(job);
+      return false;
+    },
+    [isFinal, showFinal, showStatusNotification],
+  );
+
+  const startPolling = useCallback(
+    (jobId: number, operationId: number, initialJob?: TJob) => {
+      setIsInProgress(true);
+
+      if (initialJob && handleJob(initialJob)) {
+        return;
+      }
+
+      clearPolling();
+      pollingStartedAtRef.current = Date.now();
+
+      const poll = async () => {
+        const result = await pollFn(jobId);
+        if (operationIdRef.current !== operationId) {
+          return;
+        }
+
+        if (!result.ok) {
+          resetState(false);
+          showNotificationRef.current({
+            type: NotificationType.error,
+            title: pollErrorTitle,
+            description:
+              result.error.message ||
+              'Unable to check job status. Please try again.',
+          });
+          return;
+        }
+
+        if (handleJob(result.data)) {
+          return;
+        }
+
+        const elapsed =
+          pollingStartedAtRef.current != null
+            ? Date.now() - pollingStartedAtRef.current
+            : 0;
+        if (elapsed >= timeoutMs) {
+          resetState(false);
+          showNotificationRef.current({
+            type: NotificationType.error,
+            title: timeoutTitle,
+            description: timeoutDescription,
+          });
+          return;
+        }
+
+        pollingTimeoutRef.current = setTimeout(poll, intervalMs);
+      };
+
+      pollingTimeoutRef.current = setTimeout(poll, intervalMs);
+    },
+    [
+      clearPolling,
+      handleJob,
+      resetState,
+      pollFn,
+      pollErrorTitle,
+      timeoutTitle,
+      timeoutDescription,
+      timeoutMs,
+      intervalMs,
+    ],
+  );
+
+  return {
+    isInProgress,
+    operationIdRef,
+    resetState,
+    invalidate,
+    startPolling,
+  };
+}

--- a/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
@@ -95,3 +95,26 @@ export interface DiscoveryPayloadErrorDetail {
 export interface DiscoveryPayloadErrorResponse {
   detail: DiscoveryPayloadErrorDetail;
 }
+
+export enum DiscoveryIndexingJobStatus {
+  Queued = 'QUEUED',
+  InProgress = 'IN_PROGRESS',
+  Completed = 'COMPLETED',
+  Failed = 'FAILED',
+}
+
+export interface DiscoveryIndexingJob {
+  id: number;
+  channelId: number;
+  status: DiscoveryIndexingJobStatus;
+  force: boolean;
+  /** Populated once the job reaches `Completed`; `null` while queued/running/failed. */
+  recordsTotal: number | null;
+  recordsValid: number | null;
+  recordsInvalid: number | null;
+  documentsUpserted: number | null;
+  documentsDeleted: number | null;
+  reasonForFailure?: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -19,6 +19,7 @@ import { RequestData } from '@/src/models/request-data';
 import { AutoUpdateJob } from '@/src/models/auto-update-job';
 import {
   DiscoveryDataset,
+  DiscoveryIndexingJob,
   DiscoveryUploadSummary,
 } from '@/src/models/discovery-dataset';
 import { ApiResult, MAIN_API } from './api';
@@ -47,6 +48,13 @@ export const CHANNEL_DISCOVERY_DATASETS_URL = (id?: string | number): string =>
 export const CHANNEL_DISCOVERY_DATASETS_UPLOAD_URL = (
   id?: string | number,
 ): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/upload`;
+
+export const CHANNEL_DISCOVERY_INDEXING_JOBS_URL = (
+  id?: string | number,
+): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/indexing-jobs`;
+
+export const DISCOVERY_INDEXING_JOB_ID_URL = (jobId: string | number): string =>
+  `${MAIN_API}/discovery-datasets/indexing-jobs/${jobId}`;
 
 export const CHANNEL_JOBS_URL = (id?: string | number): string =>
   `${CHANNEL_ID_URL(id)}/jobs`;
@@ -416,5 +424,38 @@ export class ChannelsApi extends BaseApi {
       void 0,
       token,
     );
+  }
+
+  triggerDiscoveryIndexingJob(
+    id: string,
+    force: boolean,
+    token: JWT | null,
+  ): Promise<ApiResult<DiscoveryIndexingJob>> {
+    return this.post(
+      `${CHANNEL_DISCOVERY_INDEXING_JOBS_URL(id)}?force=${force}`,
+      {},
+      void 0,
+      void 0,
+      token,
+    );
+  }
+
+  listDiscoveryIndexingJobs(
+    id: string,
+    limit: number,
+    offset: number,
+    token: JWT | null,
+  ): Promise<ApiResult<RequestData<DiscoveryIndexingJob>>> {
+    return this.get(
+      `${CHANNEL_DISCOVERY_INDEXING_JOBS_URL(id)}?limit=${limit}&offset=${offset}`,
+      token,
+    );
+  }
+
+  getDiscoveryIndexingJob(
+    jobId: string | number,
+    token: JWT | null,
+  ): Promise<ApiResult<DiscoveryIndexingJob>> {
+    return this.get(DISCOVERY_INDEXING_JOB_ID_URL(jobId), token);
   }
 }


### PR DESCRIPTION
### Applicable issues

- fixes #225

### Description of changes

Adds a "Reindex" action to the Discovery Datasets page, next to "Upload".

- New `ReindexConfirmDialog` (wraps the shared `ConfirmDialog`) with a "Force full reindex" checkbox and its explanation.
- New `useDiscoveryIndexingJobPolling` hook: triggers the reindex job, polls its status every 5s, shows a persistent loading toast that becomes a success/error toast on completion, and resumes polling on page load if a job is already queued/running for the channel.
- Extracted the polling/notification bookkeeping shared with `useDeduplicationJobPolling` into a new generic `useJobPolling` hook.
- Added the `DiscoveryIndexingJob`/`DiscoveryIndexingJobStatus` model, the corresponding `channels-api.ts` methods (`triggerDiscoveryIndexingJob`, `listDiscoveryIndexingJobs`, `getDiscoveryIndexingJob`), and server actions.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.