### PR TITLE
feat: add bulk, selected, and per-row delete to discovery datasets page

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/bulk/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/bulk/route.ts
@@ -1,0 +1,20 @@
+import { channelsApi } from '@/src/app/api/api';
+import { getRequestToken } from '@/src/utils/auth/get-token';
+import { apiResultToResponse } from '@/src/server/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(
+  req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const params = await context.params;
+    const token = await getRequestToken(req);
+    return apiResultToResponse(
+      await channelsApi.clearChannelDiscoveryDatasets(params.id, token),
+    );
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/statgpt-admin-frontend/src/app/api/v1/discovery-datasets/[itemId]/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/discovery-datasets/[itemId]/route.ts
@@ -1,0 +1,20 @@
+import { channelsApi } from '@/src/app/api/api';
+import { getRequestToken } from '@/src/utils/auth/get-token';
+import { apiResultToResponse } from '@/src/server/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(
+  req: Request,
+  context: { params: Promise<{ itemId: string }> },
+) {
+  try {
+    const params = await context.params;
+    const token = await getRequestToken(req);
+    return apiResultToResponse(
+      await channelsApi.removeDiscoveryDataset(params.itemId, token),
+    );
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/statgpt-admin-frontend/src/app/api/v1/discovery-datasets/bulk/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/discovery-datasets/bulk/route.ts
@@ -1,0 +1,19 @@
+import { channelsApi } from '@/src/app/api/api';
+import { getRequestToken } from '@/src/utils/auth/get-token';
+import { apiResultToResponse } from '@/src/server/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(req: Request) {
+  try {
+    const { item_ids: itemIds } = (await req.json()) as {
+      item_ids: number[];
+    };
+    const token = await getRequestToken(req);
+    return apiResultToResponse(
+      await channelsApi.removeDiscoveryDatasetsBulk(itemIds, token),
+    );
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/ActionColumn/ActionColumn.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/ActionColumn/ActionColumn.tsx
@@ -15,9 +15,11 @@ import { BASE_ICON_PROPS } from '@/src/constants/layout';
 import { DiscoveryDataset } from '@/src/models/discovery-dataset';
 import { DiscoveryDatasetDetailsView } from '../DetailsView/DiscoveryDatasetDetailsView';
 
-export const DiscoveryDatasetActionColumn: FC<CustomCellRendererProps> = ({
-  data,
-}) => {
+interface Props extends CustomCellRendererProps {
+  onDelete?: (id: number) => void;
+}
+
+export const DiscoveryDatasetActionColumn: FC<Props> = ({ data, onDelete }) => {
   const [, setIsOpen] = useState(false);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
 
@@ -34,6 +36,11 @@ export const DiscoveryDatasetActionColumn: FC<CustomCellRendererProps> = ({
           className="hover:bg-accent-primary-alpha"
           item={<ActionItem item={EntityOperation.Details} />}
           onClick={() => setIsDetailsOpen(true)}
+        />
+        <DropdownMenuItem
+          className="hover:bg-accent-primary-alpha"
+          item={<ActionItem item={EntityOperation.Delete} />}
+          onClick={() => onDelete?.((data as DiscoveryDataset).id)}
         />
       </DropdownMenu>
       {isDetailsOpen &&

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import { FC, useCallback, useState } from 'react';
-import { ColDef } from 'ag-grid-community';
-import { IconFileArrowLeft, IconRefreshDot } from '@tabler/icons-react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { ColDef, GridOptions } from 'ag-grid-community';
+import {
+  IconFileArrowLeft,
+  IconRefreshDot,
+  IconTrash,
+} from '@tabler/icons-react';
 import { createPortal } from 'react-dom';
 
 import { useAccessControl } from '@/src/context/AccessControlContext';
 import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
 import { Button } from '@/src/components/BaseComponents/Button/Button';
+import { ConfirmDialog } from '@/src/components/BaseComponents/ConfirmDialog/ConfirmDialog';
 import {
   FetchRowsArgs,
   FetchRowsResult,
@@ -18,7 +23,12 @@ import { DEFAULT_GRID_PAGE_SIZE } from '@/src/constants/columns/grid';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { DiscoveryDataset } from '@/src/models/discovery-dataset';
 import { RequestData } from '@/src/models/request-data';
-import { sendGetRequest } from '@/src/server/api';
+import { sendDeleteRequest, sendGetRequest } from '@/src/server/api';
+import {
+  CHANNEL_DISCOVERY_DATASETS_BULK_URL,
+  DISCOVERY_DATASET_ID_URL,
+  DISCOVERY_DATASETS_BULK_URL,
+} from '@/src/server/channels-api';
 import { PopUpState } from '@/src/types/modal';
 import { ValidationStatusCell } from '@/src/components/GridView/ValidationStatusCell/ValidationStatusCell';
 import { IndexingStatusCell } from '@/src/components/GridView/IndexingStatusCell/IndexingStatusCell';
@@ -31,7 +41,15 @@ interface Props {
   selectedChannelId: string;
 }
 
-const COLUMNS: ColDef[] = [
+const getColumns = (onDeleteRow: (id: number) => void): ColDef[] => [
+  {
+    width: 40,
+    maxWidth: 40,
+    headerCheckboxSelection: true,
+    checkboxSelection: true,
+    showDisabledCheckboxes: true,
+    pinned: 'left',
+  },
   { field: 'id', headerName: 'ID', width: 90 },
   { field: 'agency', headerName: 'Agency' },
   { field: 'datasetId', headerName: 'Dataset ID' },
@@ -54,6 +72,7 @@ const COLUMNS: ColDef[] = [
     width: 32,
     maxWidth: 32,
     cellRenderer: DiscoveryDatasetActionColumn,
+    cellRendererParams: { onDelete: onDeleteRow },
     cellClass: 'ag-grid__action-column',
   },
 ];
@@ -64,8 +83,63 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   const [refreshToken, setRefreshToken] = useState(0);
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showReindexConfirm, setShowReindexConfirm] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [showDeleteSelectedConfirm, setShowDeleteSelectedConfirm] =
+    useState(false);
+  const [showClearAllConfirm, setShowClearAllConfirm] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   usePageInitialLoadingSync(isInitialLoading);
+
+  useEffect(() => {
+    setSelectedIds([]);
+  }, [refreshToken]);
+
+  const gridOptions: GridOptions = useMemo(
+    () => ({
+      rowSelection: 'multiple',
+      suppressRowClickSelection: true,
+      onRowSelected: (event) => {
+        setSelectedIds(
+          event.api.getSelectedNodes().map((n) => n.data.id as number),
+        );
+      },
+    }),
+    [],
+  );
+
+  const deleteSelected = useCallback(() => {
+    withNotification(
+      sendDeleteRequest(DISCOVERY_DATASETS_BULK_URL, {
+        item_ids: selectedIds,
+      }),
+      'Failed to Delete Selected Discovery Datasets',
+    ).then((result) => {
+      if (result.ok) setRefreshToken((x) => x + 1);
+    });
+  }, [withNotification, selectedIds]);
+
+  const clearAllDatasets = useCallback(() => {
+    withNotification(
+      sendDeleteRequest(CHANNEL_DISCOVERY_DATASETS_BULK_URL(selectedChannelId)),
+      'Failed to Clear Discovery Datasets',
+    ).then((result) => {
+      if (result.ok) setRefreshToken((x) => x + 1);
+    });
+  }, [withNotification, selectedChannelId]);
+
+  const deleteRow = useCallback(
+    (id: number) => {
+      withNotification(
+        sendDeleteRequest(DISCOVERY_DATASET_ID_URL(id)),
+        'Failed to Delete Discovery Dataset',
+      ).then((result) => {
+        if (result.ok) setRefreshToken((x) => x + 1);
+      });
+    },
+    [withNotification],
+  );
+
+  const columns = useMemo(() => getColumns(deleteRow), [deleteRow]);
 
   const { triggerReindex, isReindexInProgress } =
     useDiscoveryIndexingJobPolling({
@@ -115,15 +189,29 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
             icon={<IconFileArrowLeft {...BASE_ICON_PROPS} />}
             onClick={() => setShowUploadModal(true)}
           />
+          <Button
+            cssClass="secondary ml-3"
+            title={`Delete selected (${selectedIds.length})`}
+            icon={<IconTrash {...BASE_ICON_PROPS} />}
+            disable={selectedIds.length === 0}
+            onClick={() => setShowDeleteSelectedConfirm(true)}
+          />
+          <Button
+            cssClass="secondary ml-3"
+            title="Clear all"
+            icon={<IconTrash {...BASE_ICON_PROPS} />}
+            onClick={() => setShowClearAllConfirm(true)}
+          />
         </div>
       </div>
       <div className="flex-1 min-h-0">
         <GridView<DiscoveryDataset>
-          colDefs={COLUMNS}
+          colDefs={columns}
           emptyDataTitle="No discovery datasets"
           fetchRows={fetchRows}
           pageSize={DEFAULT_GRID_PAGE_SIZE}
           refreshToken={refreshToken}
+          additionalOptions={gridOptions}
         />
       </div>
       {showUploadModal &&
@@ -140,6 +228,30 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
         onClose={({ confirmed, force }) => {
           setShowReindexConfirm(false);
           if (confirmed) triggerReindex(force);
+        }}
+      />
+      <ConfirmDialog
+        modalState={
+          showDeleteSelectedConfirm ? PopUpState.Opened : PopUpState.Closed
+        }
+        header="Delete selected discovery datasets"
+        description={`This will permanently delete ${selectedIds.length} selected discovery dataset record${selectedIds.length === 1 ? '' : 's'}.`}
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onClose={(confirmed) => {
+          setShowDeleteSelectedConfirm(false);
+          if (confirmed) deleteSelected();
+        }}
+      />
+      <ConfirmDialog
+        modalState={showClearAllConfirm ? PopUpState.Opened : PopUpState.Closed}
+        header="Clear all discovery datasets"
+        description="This will permanently delete all discovery dataset records for this channel. This action cannot be undone."
+        confirmLabel="Clear all"
+        cancelLabel="Cancel"
+        onClose={(confirmed) => {
+          setShowClearAllConfirm(false);
+          if (confirmed) clearAllDatasets();
         }}
       />
     </div>

--- a/apps/statgpt-admin-frontend/src/server/api.ts
+++ b/apps/statgpt-admin-frontend/src/server/api.ts
@@ -41,8 +41,11 @@ export const sendGetRequest = <R extends object>(
   return sendRequestSafe<object, R>(url, 'GET');
 };
 
-export const sendDeleteRequest = <R>(url: string): Promise<ApiResult<R>> => {
-  return sendRequestSafe<object, R>(url, 'DELETE');
+export const sendDeleteRequest = <T extends object, R>(
+  url: string,
+  dto?: T,
+): Promise<ApiResult<R>> => {
+  return sendRequestSafe<T, R>(url, 'DELETE', dto);
 };
 
 export function apiResultToResponse<R>(result: ApiResult<R>): Response {

--- a/apps/statgpt-admin-frontend/src/server/base-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/base-api.ts
@@ -19,11 +19,12 @@ export class BaseApi {
   protected delete<T extends object, R>(
     url: string,
     token?: JWT | null,
+    dto?: T,
   ): Promise<ApiResult<R>> {
     return this.sendRequestSafe<T, R>(
       url,
       'DELETE',
-      void 0,
+      dto,
       void 0,
       void 0,
       token,

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -56,6 +56,17 @@ export const CHANNEL_DISCOVERY_INDEXING_JOBS_URL = (
 export const DISCOVERY_INDEXING_JOB_ID_URL = (jobId: string | number): string =>
   `${MAIN_API}/discovery-datasets/indexing-jobs/${jobId}`;
 
+export const DISCOVERY_DATASETS_URL = `${MAIN_API}/discovery-datasets`;
+
+export const DISCOVERY_DATASET_ID_URL = (itemId: string | number): string =>
+  `${DISCOVERY_DATASETS_URL}/${itemId}`;
+
+export const DISCOVERY_DATASETS_BULK_URL = `${DISCOVERY_DATASETS_URL}/bulk`;
+
+export const CHANNEL_DISCOVERY_DATASETS_BULK_URL = (
+  id?: string | number,
+): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/bulk`;
+
 export const CHANNEL_JOBS_URL = (id?: string | number): string =>
   `${CHANNEL_ID_URL(id)}/jobs`;
 
@@ -457,5 +468,26 @@ export class ChannelsApi extends BaseApi {
     token: JWT | null,
   ): Promise<ApiResult<DiscoveryIndexingJob>> {
     return this.get(DISCOVERY_INDEXING_JOB_ID_URL(jobId), token);
+  }
+
+  removeDiscoveryDataset(
+    itemId: string | number,
+    token: JWT | null,
+  ): Promise<ApiResult<string>> {
+    return this.delete(DISCOVERY_DATASET_ID_URL(itemId), token);
+  }
+
+  removeDiscoveryDatasetsBulk(
+    itemIds: number[],
+    token: JWT | null,
+  ): Promise<ApiResult<string>> {
+    return this.delete(DISCOVERY_DATASETS_BULK_URL, token, itemIds);
+  }
+
+  clearChannelDiscoveryDatasets(
+    id: string,
+    token: JWT | null,
+  ): Promise<ApiResult<string>> {
+    return this.delete(CHANNEL_DISCOVERY_DATASETS_BULK_URL(id), token);
   }
 }


### PR DESCRIPTION
### Applicable issues

- #226

### Description of changes

Adds three delete affordances to the Discovery Datasets page:
- Per-row delete via the action-column menu — no confirmation (single row, easily redone)
- "Delete selected (N)" — checkbox row selection + a header button + confirmation dialog, deletes the selected ids in bulk
- "Clear all" — a channel-level header button with its own distinctly-worded (irreversible/channel-wide) confirmation dialog

All three refresh the grid on success.

Also extends `BaseApi.delete()`/`sendDeleteRequest()` with an optional request body (needed for the selected-ids bulk endpoint) and adds three new BFF routes mirroring the existing discovery-datasets route conventions.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.