### PR TITLE
fix: clear selection and show deletion toast on discovery datasets delete

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/bulk/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/bulk/route.ts
@@ -1,6 +1,5 @@
 import { channelsApi } from '@/src/app/api/api';
 import { getRequestToken } from '@/src/utils/auth/get-token';
-import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,9 +10,21 @@ export async function DELETE(
   try {
     const params = await context.params;
     const token = await getRequestToken(req);
-    return apiResultToResponse(
-      await channelsApi.clearChannelDiscoveryDatasets(params.id, token),
+    const result = await channelsApi.clearChannelDiscoveryDatasets(
+      params.id,
+      token,
     );
+
+    if (!result.ok) {
+      return Response.json(
+        { error: result.error.message },
+        { status: result.error.status || 500 },
+      );
+    }
+
+    return new Response(result.data, {
+      headers: { 'Content-Type': 'application/json' },
+    });
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/app/api/v1/discovery-datasets/bulk/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/discovery-datasets/bulk/route.ts
@@ -1,6 +1,5 @@
 import { channelsApi } from '@/src/app/api/api';
 import { getRequestToken } from '@/src/utils/auth/get-token';
-import { apiResultToResponse } from '@/src/server/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,9 +9,21 @@ export async function DELETE(req: Request) {
       item_ids: number[];
     };
     const token = await getRequestToken(req);
-    return apiResultToResponse(
-      await channelsApi.removeDiscoveryDatasetsBulk(itemIds, token),
+    const result = await channelsApi.removeDiscoveryDatasetsBulk(
+      itemIds,
+      token,
     );
+
+    if (!result.ok) {
+      return Response.json(
+        { error: result.error.message },
+        { status: result.error.status || 500 },
+      );
+    }
+
+    return new Response(result.data, {
+      headers: { 'Content-Type': 'application/json' },
+    });
   } catch {
     return Response.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -21,6 +21,8 @@ import {
 import { BASE_ICON_PROPS } from '@/src/constants/layout';
 import { DEFAULT_GRID_PAGE_SIZE } from '@/src/constants/columns/grid';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
+import { useNotification } from '@/src/context/NotificationContext';
+import { NotificationType } from '@/src/models/notification';
 import { DiscoveryDataset } from '@/src/models/discovery-dataset';
 import { RequestData } from '@/src/models/request-data';
 import { sendDeleteRequest, sendGetRequest } from '@/src/server/api';
@@ -80,6 +82,7 @@ const getColumns = (onDeleteRow: (id: number) => void): ColDef[] => [
 export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   const { setForbidden } = useAccessControl();
   const withNotification = useApiNotification();
+  const { showNotification } = useNotification();
   const [refreshToken, setRefreshToken] = useState(0);
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showReindexConfirm, setShowReindexConfirm] = useState(false);
@@ -109,23 +112,45 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
 
   const deleteSelected = useCallback(() => {
     withNotification(
-      sendDeleteRequest(DISCOVERY_DATASETS_BULK_URL, {
-        item_ids: selectedIds,
-      }),
+      sendDeleteRequest<{ item_ids: number[] }, string>(
+        DISCOVERY_DATASETS_BULK_URL,
+        { item_ids: selectedIds },
+      ),
       'Failed to Delete Selected Discovery Datasets',
     ).then((result) => {
-      if (result.ok) setRefreshToken((x) => x + 1);
+      if (result.ok) {
+        const deletedCount = (JSON.parse(result.data) as DiscoveryDataset[])
+          .length;
+        setSelectedIds([]);
+        setRefreshToken((x) => x + 1);
+        showNotification({
+          type: NotificationType.success,
+          title: 'Discovery Dataset Records Deleted',
+          description: `Deleted ${deletedCount} discovery dataset record${deletedCount === 1 ? '' : 's'}`,
+        });
+      }
     });
-  }, [withNotification, selectedIds]);
+  }, [withNotification, selectedIds, showNotification]);
 
   const clearAllDatasets = useCallback(() => {
     withNotification(
-      sendDeleteRequest(CHANNEL_DISCOVERY_DATASETS_BULK_URL(selectedChannelId)),
+      sendDeleteRequest<object, string>(
+        CHANNEL_DISCOVERY_DATASETS_BULK_URL(selectedChannelId),
+      ),
       'Failed to Clear Discovery Datasets',
     ).then((result) => {
-      if (result.ok) setRefreshToken((x) => x + 1);
+      if (result.ok) {
+        const deletedCount = (JSON.parse(result.data) as DiscoveryDataset[])
+          .length;
+        setRefreshToken((x) => x + 1);
+        showNotification({
+          type: NotificationType.success,
+          title: 'Discovery Dataset Records Deleted',
+          description: `Deleted ${deletedCount} discovery dataset record${deletedCount === 1 ? '' : 's'}`,
+        });
+      }
     });
-  }, [withNotification, selectedChannelId]);
+  }, [withNotification, selectedChannelId, showNotification]);
 
   const deleteRow = useCallback(
     (id: number) => {
@@ -133,10 +158,17 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
         sendDeleteRequest(DISCOVERY_DATASET_ID_URL(id)),
         'Failed to Delete Discovery Dataset',
       ).then((result) => {
-        if (result.ok) setRefreshToken((x) => x + 1);
+        if (result.ok) {
+          setRefreshToken((x) => x + 1);
+          showNotification({
+            type: NotificationType.success,
+            title: 'Discovery Dataset Record Deleted',
+            description: 'Deleted 1 discovery dataset record',
+          });
+        }
       });
     },
-    [withNotification],
+    [withNotification, showNotification],
   );
 
   const columns = useMemo(() => getColumns(deleteRow), [deleteRow]);


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Follow-ups to the Discovery Datasets bulk-delete feature:
- Explicitly clear row selection after confirming a "delete selected" action, instead of relying only on the incidental `refreshToken`-triggered effect.
- Show a success toast after every delete (single-row, selected-bulk, and clear-all) reporting the number of discovery dataset records deleted — including when exactly one record was deleted.
- Fixes a pre-existing double-JSON-encoding bug in the two bulk-delete BFF routes (`discovery-datasets/bulk` and `channels/[id]/discovery-datasets/bulk`), needed so the toast can report an accurate count from the backend's actual response rather than the pre-known selection count.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.