### PR TITLE
feat: show discovery dataset summary stats above grid

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/stats/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/stats/route.ts
@@ -1,0 +1,20 @@
+import { channelsApi } from '@/src/app/api/api';
+import { getRequestToken } from '@/src/utils/auth/get-token';
+import { apiResultToResponse } from '@/src/server/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const params = await context.params;
+    const token = await getRequestToken(req);
+    return apiResultToResponse(
+      await channelsApi.getChannelDiscoveryDatasetStats(params.id, token),
+    );
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsStats/DiscoveryDatasetsStats.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsStats/DiscoveryDatasetsStats.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { FC } from 'react';
+
+import { DISCOVERY_VALIDATION_STATUS_VISUALS } from '@/src/components/GridView/ValidationStatusCell/discovery-validation-status-visuals';
+import { DISCOVERY_INDEXING_STATUS_VISUALS } from '@/src/components/GridView/IndexingStatusCell/discovery-indexing-status-visuals';
+import { mergeClasses } from '@/src/utils/mergeClasses';
+import { DiscoveryDatasetStats } from '@/src/models/discovery-dataset';
+
+interface Props {
+  stats: DiscoveryDatasetStats | null;
+  isLoading: boolean;
+}
+
+const StatItem: FC<{ label: string; count: number; colorClass?: string }> = ({
+  label,
+  count,
+  colorClass,
+}) => (
+  <span className={mergeClasses('text-secondary', colorClass)}>
+    {label}: {count}
+  </span>
+);
+
+export const DiscoveryDatasetsStats: FC<Props> = ({ stats, isLoading }) => {
+  if (isLoading || !stats) return null;
+
+  return (
+    <div className="flex flex-row items-center flex-wrap gap-x-4 mb-3 text-sm">
+      <StatItem label="Total" count={stats.total} />
+      {(
+        Object.entries(stats.byValidationStatus) as [
+          keyof typeof stats.byValidationStatus,
+          number,
+        ][]
+      ).map(([status, count]) => {
+        const visual = DISCOVERY_VALIDATION_STATUS_VISUALS[status];
+        return (
+          <StatItem
+            key={status}
+            label={visual.label}
+            count={count}
+            colorClass={visual.textColorClass}
+          />
+        );
+      })}
+      {(
+        Object.entries(stats.byIndexingStatus) as [
+          keyof typeof stats.byIndexingStatus,
+          number,
+        ][]
+      ).map(([status, count]) => {
+        const visual = DISCOVERY_INDEXING_STATUS_VISUALS[status];
+        return (
+          <StatItem
+            key={status}
+            label={visual.label}
+            count={count}
+            colorClass={visual.textColorClass}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -23,7 +23,10 @@ import { DEFAULT_GRID_PAGE_SIZE } from '@/src/constants/columns/grid';
 import { useApiNotification } from '@/src/hooks/use-api-notification';
 import { useNotification } from '@/src/context/NotificationContext';
 import { NotificationType } from '@/src/models/notification';
-import { DiscoveryDataset } from '@/src/models/discovery-dataset';
+import {
+  DiscoveryDataset,
+  DiscoveryDatasetStats,
+} from '@/src/models/discovery-dataset';
 import { RequestData } from '@/src/models/request-data';
 import { sendDeleteRequest, sendGetRequest } from '@/src/server/api';
 import {
@@ -38,6 +41,7 @@ import { DiscoveryDatasetActionColumn } from './ActionColumn/ActionColumn';
 import { UploadModal } from './UploadModal/UploadModal';
 import { ReindexConfirmDialog } from './ReindexConfirmDialog/ReindexConfirmDialog';
 import { useDiscoveryIndexingJobPolling } from './useDiscoveryIndexingJobPolling';
+import { DiscoveryDatasetsStats } from './DiscoveryDatasetsStats/DiscoveryDatasetsStats';
 
 interface Props {
   selectedChannelId: string;
@@ -92,10 +96,32 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   const [showClearAllConfirm, setShowClearAllConfirm] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   usePageInitialLoadingSync(isInitialLoading);
+  const [stats, setStats] = useState<DiscoveryDatasetStats | null>(null);
+  const [isStatsLoading, setIsStatsLoading] = useState(true);
 
   useEffect(() => {
     setSelectedIds([]);
   }, [refreshToken]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsStatsLoading(true);
+
+    withNotification(
+      sendGetRequest<DiscoveryDatasetStats>(
+        `/api/v1/channels/${selectedChannelId}/discovery-datasets/stats`,
+      ),
+      'Failed to Load Discovery Dataset Stats',
+    ).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setStats(result.data);
+      setIsStatsLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedChannelId, refreshToken, withNotification]);
 
   const gridOptions: GridOptions = useMemo(
     () => ({
@@ -236,6 +262,7 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
           />
         </div>
       </div>
+      <DiscoveryDatasetsStats stats={stats} isLoading={isStatsLoading} />
       <div className="flex-1 min-h-0">
         <GridView<DiscoveryDataset>
           colDefs={columns}

--- a/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
@@ -69,6 +69,12 @@ export interface DiscoveryDataset {
   indexError?: string;
 }
 
+export interface DiscoveryDatasetStats {
+  total: number;
+  byValidationStatus: Record<DiscoveryValidationStatus, number>;
+  byIndexingStatus: Record<DiscoveryIndexingStatus, number>;
+}
+
 export interface DiscoveryUploadSummary {
   created: number;
   updated: number;

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -19,6 +19,7 @@ import { RequestData } from '@/src/models/request-data';
 import { AutoUpdateJob } from '@/src/models/auto-update-job';
 import {
   DiscoveryDataset,
+  DiscoveryDatasetStats,
   DiscoveryIndexingJob,
   DiscoveryUploadSummary,
 } from '@/src/models/discovery-dataset';
@@ -48,6 +49,10 @@ export const CHANNEL_DISCOVERY_DATASETS_URL = (id?: string | number): string =>
 export const CHANNEL_DISCOVERY_DATASETS_UPLOAD_URL = (
   id?: string | number,
 ): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/upload`;
+
+export const CHANNEL_DISCOVERY_DATASETS_STATS_URL = (
+  id?: string | number,
+): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/stats`;
 
 export const CHANNEL_DISCOVERY_INDEXING_JOBS_URL = (
   id?: string | number,
@@ -421,6 +426,13 @@ export class ChannelsApi extends BaseApi {
       `${CHANNEL_DISCOVERY_DATASETS_URL(id)}?limit=${limit}&offset=${offset}`,
       token,
     );
+  }
+
+  getChannelDiscoveryDatasetStats(
+    id: string,
+    token: JWT | null,
+  ): Promise<ApiResult<DiscoveryDatasetStats>> {
+    return this.get(CHANNEL_DISCOVERY_DATASETS_STATS_URL(id), token);
   }
 
   uploadChannelDiscoveryDatasets(


### PR DESCRIPTION
### Applicable issues

- #228

### Description of changes

Adds a summary strip above the Discovery Datasets grid showing the total dataset count plus per-status breakdowns (validation and indexing), sourced from the previously-unused `GET /channels/{channel_id}/discovery-datasets/stats` backend endpoint. Refetches whenever the grid data refreshes (upload, reindex, delete, edit) so counts stay in sync.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.