### PR TITLE
feat: add agency, validation status, and indexing status filters to discovery datasets grid

### DIFF
--- a/apps/statgpt-admin-frontend/jest.config.ts
+++ b/apps/statgpt-admin-frontend/jest.config.ts
@@ -7,5 +7,8 @@ module.exports = {
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  moduleNameMapper: {
+    '\\.svg$': '<rootDir>/src/test-utils/svgMock.tsx',
+  },
   coverageDirectory: '../../coverage/apps/statgpt-admin-frontend',
 };

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/route.ts
@@ -20,6 +20,11 @@ export async function GET(
         limit,
         offset,
         token,
+        {
+          agency: search.get('agency') ?? undefined,
+          validation_status: search.get('validation_status') ?? undefined,
+          indexing_status: search.get('indexing_status') ?? undefined,
+        },
       ),
     );
   } catch {

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { ColDef, GridOptions } from 'ag-grid-community';
+import { GridOptions } from 'ag-grid-community';
 import {
   IconFileArrowLeft,
   IconRefreshDot,
   IconTrash,
 } from '@tabler/icons-react';
 import { createPortal } from 'react-dom';
+import memoize from 'lodash/memoize';
 
 import { useAccessControl } from '@/src/context/AccessControlContext';
 import { usePageInitialLoadingSync } from '@/src/context/NavigationLoadingContext';
@@ -32,9 +33,12 @@ import {
   DISCOVERY_DATASETS_BULK_URL,
 } from '@/src/server/channels-api';
 import { PopUpState } from '@/src/types/modal';
-import { ValidationStatusCell } from '@/src/components/GridView/ValidationStatusCell/ValidationStatusCell';
-import { IndexingStatusCell } from '@/src/components/GridView/IndexingStatusCell/IndexingStatusCell';
-import { DiscoveryDatasetActionColumn } from './ActionColumn/ActionColumn';
+import { getDiscoveryDatasetsColumns } from '@/src/constants/columns/discovery-datasets';
+import { getEnumFilterValue, getTextEquals } from '@/src/utils/client/grid';
+import {
+  DiscoveryDatasetsRequestModel,
+  mapDiscoveryDatasetsRequestToQueryString,
+} from '@/src/utils/discovery-datasets';
 import { UploadModal } from './UploadModal/UploadModal';
 import { ReindexConfirmDialog } from './ReindexConfirmDialog/ReindexConfirmDialog';
 import { useDiscoveryIndexingJobPolling } from './useDiscoveryIndexingJobPolling';
@@ -42,42 +46,6 @@ import { useDiscoveryIndexingJobPolling } from './useDiscoveryIndexingJobPolling
 interface Props {
   selectedChannelId: string;
 }
-
-const getColumns = (onDeleteRow: (id: number) => void): ColDef[] => [
-  {
-    width: 40,
-    maxWidth: 40,
-    headerCheckboxSelection: true,
-    checkboxSelection: true,
-    showDisabledCheckboxes: true,
-    pinned: 'left',
-  },
-  { field: 'id', headerName: 'ID', width: 90 },
-  { field: 'agency', headerName: 'Agency' },
-  { field: 'datasetId', headerName: 'Dataset ID' },
-  { field: 'name', headerName: 'Name' },
-  { field: 'url', headerName: 'URL' },
-  { field: 'referenceArea', headerName: 'Reference Area' },
-  { field: 'timeCoverage', headerName: 'Time Coverage' },
-  { field: 'frequencyCoverage', headerName: 'Frequency Coverage' },
-  {
-    field: 'validationStatus',
-    headerName: 'Validation Status',
-    cellRenderer: ValidationStatusCell,
-  },
-  {
-    field: 'indexingStatus',
-    headerName: 'Indexing Status',
-    cellRenderer: IndexingStatusCell,
-  },
-  {
-    width: 32,
-    maxWidth: 32,
-    cellRenderer: DiscoveryDatasetActionColumn,
-    cellRendererParams: { onDelete: onDeleteRow },
-    cellClass: 'ag-grid__action-column',
-  },
-];
 
 export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   const { setForbidden } = useAccessControl();
@@ -171,7 +139,10 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
     [withNotification, showNotification],
   );
 
-  const columns = useMemo(() => getColumns(deleteRow), [deleteRow]);
+  const columns = useMemo(
+    () => getDiscoveryDatasetsColumns(deleteRow),
+    [deleteRow],
+  );
 
   const { triggerReindex, isReindexInProgress } =
     useDiscoveryIndexingJobPolling({
@@ -179,11 +150,15 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
       onCompleted: () => setRefreshToken((x) => x + 1),
     });
 
-  const fetchRows = useCallback(
-    async (args: FetchRowsArgs): Promise<FetchRowsResult<DiscoveryDataset>> => {
+  const fetchDiscoveryDatasetsPage = useCallback(
+    async (
+      params: DiscoveryDatasetsRequestModel,
+    ): Promise<FetchRowsResult<DiscoveryDataset>> => {
+      const query = mapDiscoveryDatasetsRequestToQueryString(params);
+
       const result = await withNotification(
         sendGetRequest<RequestData<DiscoveryDataset>>(
-          `/api/v1/channels/${selectedChannelId}/discovery-datasets?limit=${args.limit}&offset=${args.offset}`,
+          `/api/v1/channels/${selectedChannelId}/discovery-datasets?${query}`,
         ),
         'Failed to Load Discovery Datasets',
         [403],
@@ -201,6 +176,43 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
       return { rows: result.data.data, total: result.data.total };
     },
     [selectedChannelId, withNotification, setForbidden],
+  );
+
+  // A floating text filter fires a fetch per debounced keystroke even when the trimmed
+  // value hasn't actually changed (e.g. typing extra spaces) - memoizing by the resulting
+  // query string skips the redundant request. Rebuilding the memoized function (a fresh
+  // cache) on refreshToken means a manual refresh (delete/upload/reindex) still forces a
+  // real refetch even with unchanged filters.
+  const fetchDiscoveryDatasetsPageMemoized = useMemo(
+    () =>
+      memoize(
+        fetchDiscoveryDatasetsPage,
+        mapDiscoveryDatasetsRequestToQueryString,
+      ),
+    [fetchDiscoveryDatasetsPage, refreshToken],
+  );
+
+  const fetchRows = useCallback(
+    (args: FetchRowsArgs): Promise<FetchRowsResult<DiscoveryDataset>> => {
+      const agency = getTextEquals(args.filterModel, 'agency');
+      const validation_status = getEnumFilterValue(
+        args.filterModel,
+        'validationStatus',
+      );
+      const indexing_status = getEnumFilterValue(
+        args.filterModel,
+        'indexingStatus',
+      );
+
+      return fetchDiscoveryDatasetsPageMemoized({
+        limit: args.limit,
+        offset: args.offset,
+        agency,
+        validation_status,
+        indexing_status,
+      });
+    },
+    [fetchDiscoveryDatasetsPageMemoized],
   );
 
   return (

--- a/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.spec.ts
+++ b/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.spec.ts
@@ -1,0 +1,37 @@
+import { EnumSelectEmptyFilter } from '@/src/components/GridView/CustomFilters/EnumSelectFilter/EnumSelectEmptyFilter';
+import { EnumSelectFilter } from '@/src/components/GridView/CustomFilters/EnumSelectFilter/EnumSelectFilter';
+import { getDiscoveryDatasetsColumns } from './discovery-datasets';
+
+describe('getDiscoveryDatasetsColumns', () => {
+  const columns = getDiscoveryDatasetsColumns(() => {});
+  const byField = (field: string) => columns.find((c) => c.field === field);
+
+  it('gives agency an exact-match text filter, matching the backend agency_key equality check', () => {
+    expect(byField('agency')).toMatchObject({
+      filter: 'agTextColumnFilter',
+      filterParams: expect.objectContaining({
+        filterOptions: ['equals'],
+        defaultOption: 'equals',
+      }),
+    });
+  });
+
+  it('gives validationStatus an enum select filter with an empty floating filter', () => {
+    expect(byField('validationStatus')).toMatchObject({
+      filter: EnumSelectFilter,
+      floatingFilterComponent: EnumSelectEmptyFilter,
+    });
+  });
+
+  it('gives indexingStatus an enum select filter with an empty floating filter', () => {
+    expect(byField('indexingStatus')).toMatchObject({
+      filter: EnumSelectFilter,
+      floatingFilterComponent: EnumSelectEmptyFilter,
+    });
+  });
+
+  it('does not add a filter to unsupported free-text columns', () => {
+    expect(byField('name')?.filter).toBeUndefined();
+    expect(byField('url')?.filter).toBeUndefined();
+  });
+});

--- a/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.ts
+++ b/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.ts
@@ -1,0 +1,80 @@
+import { ColDef } from 'ag-grid-community';
+
+import { EnumSelectEmptyFilter } from '@/src/components/GridView/CustomFilters/EnumSelectFilter/EnumSelectEmptyFilter';
+import { EnumSelectFilter } from '@/src/components/GridView/CustomFilters/EnumSelectFilter/EnumSelectFilter';
+import { ValidationStatusCell } from '@/src/components/GridView/ValidationStatusCell/ValidationStatusCell';
+import { IndexingStatusCell } from '@/src/components/GridView/IndexingStatusCell/IndexingStatusCell';
+import { DiscoveryDatasetActionColumn } from '@/src/components/DiscoveryDatasetsView/ActionColumn/ActionColumn';
+import {
+  DISCOVERY_INDEXING_STATUS_LABEL,
+  DISCOVERY_VALIDATION_STATUS_LABEL,
+  DiscoveryIndexingStatus,
+  DiscoveryValidationStatus,
+} from '@/src/models/discovery-dataset';
+
+// The backend matches agency against a normalized natural-key column with `==`, not a
+// substring search, so the filter must be exact-match too - "contains" would silently
+// return nothing for a partial name.
+const EQUALS_TEXT_FILTER = {
+  filterOptions: ['equals'],
+  defaultOption: 'equals',
+  maxNumConditions: 1,
+  debounceMs: 400,
+};
+
+export const getDiscoveryDatasetsColumns = (
+  onDeleteRow: (id: number) => void,
+): ColDef[] => [
+  {
+    width: 40,
+    maxWidth: 40,
+    headerCheckboxSelection: true,
+    checkboxSelection: true,
+    showDisabledCheckboxes: true,
+    pinned: 'left',
+  },
+  { field: 'id', headerName: 'ID', width: 90 },
+  {
+    field: 'agency',
+    headerName: 'Agency',
+    filter: 'agTextColumnFilter',
+    filterParams: EQUALS_TEXT_FILTER,
+  },
+  { field: 'datasetId', headerName: 'Dataset ID' },
+  { field: 'name', headerName: 'Name' },
+  { field: 'url', headerName: 'URL' },
+  { field: 'referenceArea', headerName: 'Reference Area' },
+  { field: 'timeCoverage', headerName: 'Time Coverage' },
+  { field: 'frequencyCoverage', headerName: 'Frequency Coverage' },
+  {
+    field: 'validationStatus',
+    headerName: 'Validation Status',
+    cellRenderer: ValidationStatusCell,
+    filter: EnumSelectFilter,
+    filterParams: {
+      values: Object.values(DiscoveryValidationStatus),
+      formatValue: (v: string) =>
+        DISCOVERY_VALIDATION_STATUS_LABEL[v as DiscoveryValidationStatus] ?? v,
+    },
+    floatingFilterComponent: EnumSelectEmptyFilter,
+  },
+  {
+    field: 'indexingStatus',
+    headerName: 'Indexing Status',
+    cellRenderer: IndexingStatusCell,
+    filter: EnumSelectFilter,
+    filterParams: {
+      values: Object.values(DiscoveryIndexingStatus),
+      formatValue: (v: string) =>
+        DISCOVERY_INDEXING_STATUS_LABEL[v as DiscoveryIndexingStatus] ?? v,
+    },
+    floatingFilterComponent: EnumSelectEmptyFilter,
+  },
+  {
+    width: 32,
+    maxWidth: 32,
+    cellRenderer: DiscoveryDatasetActionColumn,
+    cellRendererParams: { onDelete: onDeleteRow },
+    cellClass: 'ag-grid__action-column',
+  },
+];

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -24,6 +24,7 @@ import {
 } from '@/src/models/discovery-dataset';
 import { ApiResult, MAIN_API } from './api';
 import { BaseApi } from './base-api';
+import { mapDiscoveryDatasetsRequestToQueryString } from '@/src/utils/discovery-datasets';
 import { Job, JobStatus } from '@/src/models/job';
 import { DeduplicationJob } from '@/src/models/deduplication-job';
 
@@ -416,11 +417,18 @@ export class ChannelsApi extends BaseApi {
     limit: number,
     offset: number,
     token: JWT | null,
+    filters?: {
+      agency?: string;
+      validation_status?: string;
+      indexing_status?: string;
+    },
   ): Promise<ApiResult<RequestData<DiscoveryDataset>>> {
-    return this.get(
-      `${CHANNEL_DISCOVERY_DATASETS_URL(id)}?limit=${limit}&offset=${offset}`,
-      token,
-    );
+    const query = mapDiscoveryDatasetsRequestToQueryString({
+      limit,
+      offset,
+      ...filters,
+    });
+    return this.get(`${CHANNEL_DISCOVERY_DATASETS_URL(id)}?${query}`, token);
   }
 
   uploadChannelDiscoveryDatasets(

--- a/apps/statgpt-admin-frontend/src/test-utils/svgMock.tsx
+++ b/apps/statgpt-admin-frontend/src/test-utils/svgMock.tsx
@@ -1,0 +1,3 @@
+export default function SvgMock() {
+  return null;
+}

--- a/apps/statgpt-admin-frontend/src/utils/discovery-datasets.spec.ts
+++ b/apps/statgpt-admin-frontend/src/utils/discovery-datasets.spec.ts
@@ -1,0 +1,38 @@
+import { mapDiscoveryDatasetsRequestToQueryString } from './discovery-datasets';
+
+describe('mapDiscoveryDatasetsRequestToQueryString', () => {
+  it('includes limit and offset', () => {
+    const query = mapDiscoveryDatasetsRequestToQueryString({
+      limit: 100,
+      offset: 0,
+    });
+
+    expect(query).toBe('limit=100&offset=0');
+  });
+
+  it('includes agency, validation_status and indexing_status when set', () => {
+    const query = mapDiscoveryDatasetsRequestToQueryString({
+      limit: 100,
+      offset: 200,
+      agency: 'World Bank',
+      validation_status: 'VALID',
+      indexing_status: 'INDEXED',
+    });
+
+    expect(query).toBe(
+      'limit=100&offset=200&agency=World+Bank&validation_status=VALID&indexing_status=INDEXED',
+    );
+  });
+
+  it('omits undefined and empty filter values', () => {
+    const query = mapDiscoveryDatasetsRequestToQueryString({
+      limit: 100,
+      offset: 0,
+      agency: undefined,
+      validation_status: '',
+      indexing_status: undefined,
+    });
+
+    expect(query).toBe('limit=100&offset=0');
+  });
+});

--- a/apps/statgpt-admin-frontend/src/utils/discovery-datasets.ts
+++ b/apps/statgpt-admin-frontend/src/utils/discovery-datasets.ts
@@ -1,0 +1,21 @@
+export interface DiscoveryDatasetsRequestModel {
+  limit: number;
+  offset: number;
+  agency?: string;
+  validation_status?: string;
+  indexing_status?: string;
+}
+
+export function mapDiscoveryDatasetsRequestToQueryString(
+  params: DiscoveryDatasetsRequestModel,
+): string {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && String(value).trim() !== '') {
+      searchParams.set(key, String(value));
+    }
+  });
+
+  return searchParams.toString();
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- #229

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Adds agency (exact match), validation status, and indexing status filters to the Discovery Datasets grid, forwarded through the BFF to the backend's existing filter params. Also fixes two pre-existing Jest/ESLint gaps blocking this repo's first test suite (SVG imports, test-file naming).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.