### PR TITLE
feat: render multi-value dataset fields as lists in Grade C details popup

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/BaseComponents/DataField/DataFieldList.test.tsx
+++ b/apps/statgpt-admin-frontend/src/components/BaseComponents/DataField/DataFieldList.test.tsx
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+/* global describe, it, expect */
+import { render, screen } from '@testing-library/react';
+
+import { DataFieldList } from './DataFieldList';
+
+describe('DataFieldList', () => {
+  it('renders a bulleted list when the value has multiple ;-separated segments', () => {
+    render(
+      <DataFieldList
+        label="Indicators Coverage"
+        value="GDP; CPI; Unemployment rate"
+      />,
+    );
+
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((item) => item.textContent)).toEqual([
+      'GDP',
+      'CPI',
+      'Unemployment rate',
+    ]);
+  });
+
+  it('falls back to plain text when the value has no delimiter', () => {
+    render(<DataFieldList label="Indicators Coverage" value="GDP only" />);
+
+    expect(screen.queryByRole('list')).toBeNull();
+    expect(screen.getByText('GDP only')).not.toBeNull();
+  });
+
+  it('falls back to plain text for an empty value', () => {
+    render(<DataFieldList label="Missing Indicators" value="" />);
+
+    expect(screen.queryByRole('list')).toBeNull();
+    expect(
+      screen.getByText('Missing Indicators').nextSibling?.textContent,
+    ).toBe('');
+  });
+
+  it('drops empty segments from malformed input instead of rendering blank items', () => {
+    render(<DataFieldList label="Reference Area" value="USA;; Canada; " />);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((item) => item.textContent)).toEqual(['USA', 'Canada']);
+  });
+
+  it('falls back to plain text when malformed input has only one real segment', () => {
+    render(<DataFieldList label="Frequency Coverage" value="Monthly;;  ; " />);
+
+    expect(screen.queryByRole('list')).toBeNull();
+    expect(
+      screen.getByText('Frequency Coverage').nextSibling?.textContent,
+    ).toBe('Monthly;;  ; ');
+  });
+});

--- a/apps/statgpt-admin-frontend/src/components/BaseComponents/DataField/DataFieldList.tsx
+++ b/apps/statgpt-admin-frontend/src/components/BaseComponents/DataField/DataFieldList.tsx
@@ -1,0 +1,40 @@
+import { DataField } from './DataField';
+
+/**
+ * Renders a delimited, multi-value field as a bulleted list. Falls back to
+ * plain text (same as `DataField`) when the value doesn't split into at
+ * least two non-empty segments - covers empty values, single values, and
+ * malformed/inconsistent delimiters.
+ * @param label - field label
+ * @param value - raw delimited string value
+ * @param delimiter - separator to split on, defaults to `;`
+ */
+export const DataFieldList = ({
+  label,
+  value = '',
+  delimiter = ';',
+}: {
+  label: string;
+  value?: string | null;
+  delimiter?: string;
+}) => {
+  const items = (value ?? '')
+    .split(delimiter)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  if (items.length < 2) {
+    return <DataField label={label} value={value} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="tiny text-secondary">{label}</span>
+      <ul className="body text-primary list-disc pl-4">
+        {items.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DetailsView/DiscoveryDatasetDetailsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DetailsView/DiscoveryDatasetDetailsView.tsx
@@ -3,6 +3,7 @@
 import { FC } from 'react';
 
 import { DataField } from '@/src/components/BaseComponents/DataField/DataField';
+import { DataFieldList } from '@/src/components/BaseComponents/DataField/DataFieldList';
 import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { Modal } from '@/src/components/Modal/Modal';
 import {
@@ -29,19 +30,25 @@ export const DiscoveryDatasetDetailsView: FC<Props> = ({ data, close }) => {
         <DataField label="Name" value={data.name} />
         <DataField label="Description" value={data.description} />
         <DataField label="URL" value={data.url} />
-        <DataField label="Reference Area" value={data.referenceArea} />
+        <DataFieldList label="Reference Area" value={data.referenceArea} />
         <DataField label="Regional Coverage" value={data.regionalCoverage} />
         <DataField
           label="Excluded Regional Values"
           value={data.excludedRegionalValues}
         />
         <DataField label="Time Coverage" value={data.timeCoverage} />
-        <DataField label="Frequency Coverage" value={data.frequencyCoverage} />
-        <DataField
+        <DataFieldList
+          label="Frequency Coverage"
+          value={data.frequencyCoverage}
+        />
+        <DataFieldList
           label="Indicators Coverage"
           value={data.indicatorsCoverage}
         />
-        <DataField label="Missing Indicators" value={data.missingIndicators} />
+        <DataFieldList
+          label="Missing Indicators"
+          value={data.missingIndicators}
+        />
         <DataField label="Channel ID" value={String(data.channelId ?? '')} />
         <DataField
           label="Validation Status"


### PR DESCRIPTION
### Applicable issues

- #239

### Description of changes

Renders multi-value fields (Indicators Coverage, Missing Indicators, Reference Area, Frequency Coverage) in the Grade C dataset details popup as a bulleted list instead of a raw ';'-joined string, via a new `DataFieldList` component. Falls back to plain text for empty/single-value/malformed input.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.