### PR TITLE
feat: add upload mode selection with delete-absent-records option for Grade C dataset uploads

### DIFF
--- a/apps/statgpt-admin-frontend/next-env.d.ts
+++ b/apps/statgpt-admin-frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./../../dist/apps/statgpt-admin-frontend/.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/statgpt-admin-frontend/next-env.d.ts
+++ b/apps/statgpt-admin-frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./../../dist/apps/statgpt-admin-frontend/.next/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/upload/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/upload/route.ts
@@ -1,4 +1,5 @@
 import { channelsApi } from '@/src/app/api/api';
+import { DiscoveryUploadMode } from '@/src/models/discovery-dataset';
 import { getRequestToken } from '@/src/utils/auth/get-token';
 
 export const runtime = 'nodejs';
@@ -11,9 +12,18 @@ export async function POST(
     const params = await context.params;
     const formData = await req.formData();
     const token = await getRequestToken(req);
+
+    const modeParam = new URL(req.url).searchParams.get('mode');
+    const mode = (Object.values(DiscoveryUploadMode) as string[]).includes(
+      modeParam ?? '',
+    )
+      ? (modeParam as DiscoveryUploadMode)
+      : DiscoveryUploadMode.Upsert;
+
     const result = await channelsApi.uploadChannelDiscoveryDatasets(
       params.id,
       formData,
+      mode,
       token,
     );
 

--- a/apps/statgpt-admin-frontend/src/components/BaseComponents/Fields/Field.tsx
+++ b/apps/statgpt-admin-frontend/src/components/BaseComponents/Fields/Field.tsx
@@ -1,14 +1,20 @@
 import { FC } from 'react';
 
+import { mergeClasses } from '@/src/utils/mergeClasses';
+
 interface Props {
   fieldTitle?: string;
   htmlFor: string;
   optional?: boolean;
+  className?: string;
 }
 
-const Field: FC<Props> = ({ fieldTitle, htmlFor, optional }) => {
+const Field: FC<Props> = ({ fieldTitle, htmlFor, optional, className }) => {
   return (
-    <label className="tiny mb-2 text-secondary" htmlFor={htmlFor}>
+    <label
+      className={mergeClasses('tiny mb-2 text-secondary', className)}
+      htmlFor={htmlFor}
+    >
       {fieldTitle && (
         <>
           {fieldTitle}

--- a/apps/statgpt-admin-frontend/src/components/BaseComponents/LoadFileArea/EmptyFileArea.tsx
+++ b/apps/statgpt-admin-frontend/src/components/BaseComponents/LoadFileArea/EmptyFileArea.tsx
@@ -5,14 +5,21 @@ import { useDrop } from 'react-dnd';
 import { NativeTypes } from 'react-dnd-html5-backend';
 
 import { Button } from '@/src/components/BaseComponents/Button/Button';
+import { mergeClasses } from '@/src/utils/mergeClasses';
 
 interface Props {
   emptyTitle: string;
   acceptTypes: string;
+  className?: string;
   onChange: (url?: FileList) => void;
 }
 
-const EmptyFileArea: FC<Props> = ({ onChange, emptyTitle, acceptTypes }) => {
+const EmptyFileArea: FC<Props> = ({
+  onChange,
+  emptyTitle,
+  acceptTypes,
+  className,
+}) => {
   const dropRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -66,8 +73,8 @@ const EmptyFileArea: FC<Props> = ({ onChange, emptyTitle, acceptTypes }) => {
         onKeyDown={handleKeyDown}
         className="flex flex-col items-center cursor-pointer h-full w-full text-secondary tiny justify-center"
       >
-        <p className="mb-1">{emptyTitle}</p>
-        <p className="mb-0.5"> Or</p>
+        <p className={mergeClasses('mb-1', className)}>{emptyTitle}</p>
+        <p className={mergeClasses('mb-0.5', className)}> Or</p>
         <Button
           cssClass="tertiary"
           title={'Browse'}

--- a/apps/statgpt-admin-frontend/src/components/BaseComponents/LoadFileArea/LoadFileArea.tsx
+++ b/apps/statgpt-admin-frontend/src/components/BaseComponents/LoadFileArea/LoadFileArea.tsx
@@ -12,12 +12,14 @@ interface LoadFileAreaProps {
   files?: FileList;
   acceptTypes: string;
   iconBeforeInput?: ReactNode;
+  inputClassName?: string;
   onChangeFile: (value?: FileList) => void;
 }
 
 interface LoadFileAreaFieldProps extends LoadFileAreaProps {
   fieldTitle: string;
   elementId: string;
+  labelClassName?: string;
 }
 
 export const LoadFileArea: FC<LoadFileAreaProps> = ({
@@ -25,6 +27,7 @@ export const LoadFileArea: FC<LoadFileAreaProps> = ({
   emptyTitle,
   files,
   iconBeforeInput,
+  inputClassName,
   onChangeFile,
 }) => {
   const removeFile = () => {
@@ -46,12 +49,14 @@ export const LoadFileArea: FC<LoadFileAreaProps> = ({
         onChange={onChangeFile}
         acceptTypes={acceptTypes}
         emptyTitle={emptyTitle}
+        className={inputClassName}
       />
     </DndProvider>
   ) : (
     <InputWithIcon
       inputId="file"
       value={files[0].name}
+      cssClass={inputClassName}
       iconAfterInput={removeFile()}
       iconBeforeInput={iconBeforeInput}
       onChangeFile={onChangeFile}
@@ -62,11 +67,16 @@ export const LoadFileArea: FC<LoadFileAreaProps> = ({
 export const LoadFileAreaField: FC<LoadFileAreaFieldProps> = ({
   fieldTitle,
   elementId,
+  labelClassName,
   ...props
 }) => {
   return (
     <div className="flex flex-col">
-      <Field fieldTitle={fieldTitle} htmlFor={elementId} />
+      <Field
+        fieldTitle={fieldTitle}
+        htmlFor={elementId}
+        className={labelClassName}
+      />
 
       <LoadFileArea {...props} />
     </div>

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
@@ -3,12 +3,14 @@
 import { FC, useState } from 'react';
 
 import { Button } from '@/src/components/BaseComponents/Button/Button';
+import Checkbox from '@/src/components/BaseComponents/Checkbox/Checkbox';
 import { LoadFileAreaField } from '@/src/components/BaseComponents/LoadFileArea/LoadFileArea';
 import LoaderSmall from '@/src/components/BaseComponents/Loader/Loader';
 import { Modal } from '@/src/components/Modal/Modal';
 import {
   DiscoveryPayloadErrorResponse,
   DiscoveryPayloadProblem,
+  DiscoveryUploadMode,
   DiscoveryUploadSummary,
 } from '@/src/models/discovery-dataset';
 import { sendPostRequest } from '@/src/server/api';
@@ -33,6 +35,7 @@ const SUMMARY_LABELS: { key: keyof DiscoveryUploadSummary; label: string }[] = [
 export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
   const [step, setStep] = useState<Step>('select');
   const [files, setFiles] = useState<FileList | undefined>(void 0);
+  const [deleteAbsent, setDeleteAbsent] = useState(false);
   const [summary, setSummary] = useState<DiscoveryUploadSummary | undefined>(
     void 0,
   );
@@ -43,11 +46,14 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
     if (!files) return;
     setStep('uploading');
 
+    const mode = deleteAbsent
+      ? DiscoveryUploadMode.Replace
+      : DiscoveryUploadMode.Upsert;
     const formData = new FormData();
     formData.append('file', files[0], files[0].name);
 
     const result = await sendPostRequest<FormData, DiscoveryUploadSummary>(
-      `/api/v1/channels/${channelId}/discovery-datasets/upload`,
+      `/api/v1/channels/${channelId}/discovery-datasets/upload?mode=${mode}`,
       formData,
     );
 
@@ -70,20 +76,44 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
     close();
   };
 
+  const handleFilesChange = (newFiles: FileList | undefined) => {
+    setFiles(newFiles);
+    if (!newFiles) setDeleteAbsent(false);
+  };
+
   return (
     <Modal title="Upload Grade C Datasets" close={close} width="600px">
       <></>
 
       <div className="flex flex-col gap-y-6 min-h-[200px] p-4">
         {step === 'select' && (
-          <LoadFileAreaField
-            elementId="file"
-            fieldTitle="File"
-            acceptTypes=".csv,.xlsx"
-            emptyTitle="Drop file here"
-            files={files}
-            onChangeFile={setFiles}
-          />
+          <>
+            <LoadFileAreaField
+              elementId="file"
+              fieldTitle="File"
+              acceptTypes=".csv,.xlsx"
+              emptyTitle="Drop file here"
+              files={files}
+              onChangeFile={handleFilesChange}
+              labelClassName="text-sm"
+              inputClassName="text-sm"
+            />
+
+            {files && (
+              <div className="flex flex-col gap-2">
+                <Checkbox
+                  id="upload-delete-absent"
+                  label="Also delete records not in this file"
+                  checked={deleteAbsent}
+                  onChange={(value) => setDeleteAbsent(!!value)}
+                />
+                <p className="whitespace-pre-wrap text-sm text-secondary">
+                  Records present in the channel but missing from the uploaded
+                  file will be permanently deleted.
+                </p>
+              </div>
+            )}
+          </>
         )}
 
         {step === 'uploading' && <LoaderSmall containerClassName="h-[150px]" />}
@@ -151,9 +181,9 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
             <Button cssClass="secondary mr-3" title="Cancel" onClick={close} />
             <Button
               cssClass="primary"
-              title="Next"
+              title="Upload"
               disable={files == null}
-              onClick={() => upload()}
+              onClick={upload}
             />
           </>
         )}

--- a/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
@@ -75,6 +75,11 @@ export interface DiscoveryDatasetStats {
   byIndexingStatus: Record<DiscoveryIndexingStatus, number>;
 }
 
+export enum DiscoveryUploadMode {
+  Upsert = 'upsert',
+  Replace = 'replace',
+}
+
 export interface DiscoveryUploadSummary {
   created: number;
   updated: number;

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -21,6 +21,7 @@ import {
   DiscoveryDataset,
   DiscoveryDatasetStats,
   DiscoveryIndexingJob,
+  DiscoveryUploadMode,
   DiscoveryUploadSummary,
 } from '@/src/models/discovery-dataset';
 import { ApiResult, MAIN_API } from './api';
@@ -446,10 +447,11 @@ export class ChannelsApi extends BaseApi {
   uploadChannelDiscoveryDatasets(
     id: string,
     formData: FormData,
+    mode: DiscoveryUploadMode,
     token: JWT | null,
   ): Promise<ApiResult<DiscoveryUploadSummary>> {
     return this.post(
-      `${CHANNEL_DISCOVERY_DATASETS_UPLOAD_URL(id)}?mode=upsert`,
+      `${CHANNEL_DISCOVERY_DATASETS_UPLOAD_URL(id)}?mode=${mode}`,
       formData,
       void 0,
       void 0,


### PR DESCRIPTION
### Applicable issues

- #245

### Description of changes

Adds an upload mode selection to the Grade C (discovery datasets) upload flow:

- `DiscoveryUploadMode` (`upsert`/`replace`) is threaded through `channels-api.ts`, the `/api/v1/channels/[id]/discovery-datasets/upload` BFF route, and `UploadModal`.
- After picking a file, the upload modal now shows a "Also delete records not in this file" checkbox with a description of what it does. Checking it switches the upload to `replace` mode; leaving it unchecked keeps the existing `upsert` behavior. The checkbox is hidden again if the file is removed.
- Font sizes in the upload modal's file field ("File *" label, selected filename, and the "Drop file here" / "Or" empty-state text) are bumped from 12px to 14px for readability, scoped to this modal only via new optional `className`/`labelClassName`/`inputClassName` override props on `Field`, `LoadFileArea`, and `EmptyFileArea` — every other caller keeps its default 12px styling.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.