### PR TITLE
feat: drive Grade C agency and status filters from backend-reported values

### DIFF
--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -36,8 +36,11 @@ import {
   DISCOVERY_DATASETS_BULK_URL,
 } from '@/src/server/channels-api';
 import { PopUpState } from '@/src/types/modal';
-import { getDiscoveryDatasetsColumns } from '@/src/constants/columns/discovery-datasets';
-import { getEnumFilterValue, getTextEquals } from '@/src/utils/client/grid';
+import {
+  getDiscoveryDatasetsColumns,
+  getDiscoveryDatasetsFilterValues,
+} from '@/src/constants/columns/discovery-datasets';
+import { getEnumFilterValue } from '@/src/utils/client/grid';
 import {
   DiscoveryDatasetsRequestModel,
   mapDiscoveryDatasetsRequestToQueryString,
@@ -166,8 +169,12 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   );
 
   const columns = useMemo(
-    () => getDiscoveryDatasetsColumns(deleteRow),
-    [deleteRow],
+    () =>
+      getDiscoveryDatasetsColumns(
+        deleteRow,
+        getDiscoveryDatasetsFilterValues(stats),
+      ),
+    [deleteRow, stats],
   );
 
   const { triggerReindex, isReindexInProgress } =
@@ -220,7 +227,7 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
 
   const fetchRows = useCallback(
     (args: FetchRowsArgs): Promise<FetchRowsResult<DiscoveryDataset>> => {
-      const agency = getTextEquals(args.filterModel, 'agency');
+      const agency = getEnumFilterValue(args.filterModel, 'agency');
       const validation_status = getEnumFilterValue(
         args.filterModel,
         'validationStatus',

--- a/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.spec.ts
+++ b/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.spec.ts
@@ -1,18 +1,69 @@
 import { EnumSelectEmptyFilter } from '@/src/components/GridView/CustomFilters/EnumSelectFilter/EnumSelectEmptyFilter';
 import { EnumSelectFilter } from '@/src/components/GridView/CustomFilters/EnumSelectFilter/EnumSelectFilter';
-import { getDiscoveryDatasetsColumns } from './discovery-datasets';
+import {
+  DiscoveryIndexingStatus,
+  DiscoveryValidationStatus,
+} from '@/src/models/discovery-dataset';
+import {
+  getDiscoveryDatasetsColumns,
+  getDiscoveryDatasetsFilterValues,
+} from './discovery-datasets';
+
+describe('getDiscoveryDatasetsFilterValues', () => {
+  it('lists agencies in the order the stats map holds them', () => {
+    const values = getDiscoveryDatasetsFilterValues({
+      total: 3,
+      byValidationStatus: {} as never,
+      byIndexingStatus: {} as never,
+      byAgency: { 'Bank Indonesia (BI)': 2, OECD: 1 },
+    });
+
+    expect(values.agency).toEqual(['Bank Indonesia (BI)', 'OECD']);
+  });
+
+  it('drops statuses the channel holds no records for', () => {
+    const values = getDiscoveryDatasetsFilterValues({
+      total: 3,
+      byValidationStatus: {
+        [DiscoveryValidationStatus.Valid]: 3,
+        [DiscoveryValidationStatus.Invalid]: 0,
+        [DiscoveryValidationStatus.NotValidated]: 0,
+      },
+      byIndexingStatus: {
+        [DiscoveryIndexingStatus.Indexed]: 3,
+        [DiscoveryIndexingStatus.New]: 0,
+        [DiscoveryIndexingStatus.Outdated]: 0,
+        [DiscoveryIndexingStatus.Failed]: 0,
+      },
+      byAgency: {},
+    });
+
+    expect(values.validationStatus).toEqual([DiscoveryValidationStatus.Valid]);
+    expect(values.indexingStatus).toEqual([DiscoveryIndexingStatus.Indexed]);
+  });
+
+  it('returns empty lists with no stats yet', () => {
+    expect(getDiscoveryDatasetsFilterValues(null)).toEqual({
+      agency: [],
+      validationStatus: [],
+      indexingStatus: [],
+    });
+  });
+});
 
 describe('getDiscoveryDatasetsColumns', () => {
-  const columns = getDiscoveryDatasetsColumns(() => {});
+  const columns = getDiscoveryDatasetsColumns(() => {}, {
+    agency: ['Bank Indonesia (BI)', 'OECD'],
+    validationStatus: [DiscoveryValidationStatus.Valid],
+    indexingStatus: [DiscoveryIndexingStatus.Indexed],
+  });
   const byField = (field: string) => columns.find((c) => c.field === field);
 
-  it('gives agency an exact-match text filter, matching the backend agency_key equality check', () => {
+  it('gives agency an enum select filter populated from the channel data, with an empty floating filter', () => {
     expect(byField('agency')).toMatchObject({
-      filter: 'agTextColumnFilter',
-      filterParams: expect.objectContaining({
-        filterOptions: ['equals'],
-        defaultOption: 'equals',
-      }),
+      filter: EnumSelectFilter,
+      filterParams: { values: ['Bank Indonesia (BI)', 'OECD'] },
+      floatingFilterComponent: EnumSelectEmptyFilter,
     });
   });
 

--- a/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.ts
+++ b/apps/statgpt-admin-frontend/src/constants/columns/discovery-datasets.ts
@@ -8,22 +8,36 @@ import { DiscoveryDatasetActionColumn } from '@/src/components/DiscoveryDatasets
 import {
   DISCOVERY_INDEXING_STATUS_LABEL,
   DISCOVERY_VALIDATION_STATUS_LABEL,
+  DiscoveryDatasetStats,
   DiscoveryIndexingStatus,
   DiscoveryValidationStatus,
 } from '@/src/models/discovery-dataset';
 
-// The backend matches agency against a normalized natural-key column with `==`, not a
-// substring search, so the filter must be exact-match too - "contains" would silently
-// return nothing for a partial name.
-const EQUALS_TEXT_FILTER = {
-  filterOptions: ['equals'],
-  defaultOption: 'equals',
-  maxNumConditions: 1,
-  debounceMs: 400,
-};
+/** The statuses/agencies a channel's data actually holds, keyed by column field. */
+export interface DiscoveryDatasetsFilterValues {
+  agency: readonly string[];
+  validationStatus: readonly string[];
+  indexingStatus: readonly string[];
+}
+
+const presentKeys = <K extends string>(
+  byStatus: Record<K, number> | undefined,
+): K[] =>
+  Object.entries(byStatus ?? {})
+    .filter(([, count]) => (count as number) > 0)
+    .map(([status]) => status as K);
+
+export const getDiscoveryDatasetsFilterValues = (
+  stats: DiscoveryDatasetStats | null,
+): DiscoveryDatasetsFilterValues => ({
+  agency: Object.keys(stats?.byAgency ?? {}),
+  validationStatus: presentKeys(stats?.byValidationStatus),
+  indexingStatus: presentKeys(stats?.byIndexingStatus),
+});
 
 export const getDiscoveryDatasetsColumns = (
   onDeleteRow: (id: number) => void,
+  filterValues: DiscoveryDatasetsFilterValues,
 ): ColDef[] => [
   {
     width: 40,
@@ -38,8 +52,9 @@ export const getDiscoveryDatasetsColumns = (
   {
     field: 'agency',
     headerName: 'Agency',
-    filter: 'agTextColumnFilter',
-    filterParams: EQUALS_TEXT_FILTER,
+    filter: EnumSelectFilter,
+    filterParams: { values: filterValues.agency },
+    floatingFilterComponent: EnumSelectEmptyFilter,
     sortable: false,
   },
   { field: 'datasetId', headerName: 'Dataset ID', sortable: false },
@@ -62,7 +77,7 @@ export const getDiscoveryDatasetsColumns = (
     cellRenderer: ValidationStatusCell,
     filter: EnumSelectFilter,
     filterParams: {
-      values: Object.values(DiscoveryValidationStatus),
+      values: filterValues.validationStatus,
       formatValue: (v: string) =>
         DISCOVERY_VALIDATION_STATUS_LABEL[v as DiscoveryValidationStatus] ?? v,
     },
@@ -75,7 +90,7 @@ export const getDiscoveryDatasetsColumns = (
     cellRenderer: IndexingStatusCell,
     filter: EnumSelectFilter,
     filterParams: {
-      values: Object.values(DiscoveryIndexingStatus),
+      values: filterValues.indexingStatus,
       formatValue: (v: string) =>
         DISCOVERY_INDEXING_STATUS_LABEL[v as DiscoveryIndexingStatus] ?? v,
     },

--- a/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
@@ -73,6 +73,7 @@ export interface DiscoveryDatasetStats {
   total: number;
   byValidationStatus: Record<DiscoveryValidationStatus, number>;
   byIndexingStatus: Record<DiscoveryIndexingStatus, number>;
+  byAgency: Record<string, number>;
 }
 
 export enum DiscoveryUploadMode {


### PR DESCRIPTION
### Applicable issues

- #254
- #246

### Description of changes

Replaces the free-text agency filter on the Grade C (discovery datasets) grid with a picker, and drives both the validation and indexing status filters from the actual values present in the channel's data instead of a hardcoded list.

- `DiscoveryDatasetStats` gains `byAgency`, mapping the backend's deduplicated, count-ordered agency values.
- `getDiscoveryDatasetsFilterValues` derives the agency filter's options from `byAgency`, and the status filters' options from `byValidationStatus`/`byIndexingStatus` entries with a non-zero count.
- The agency column now uses the same `EnumSelectFilter`/`EnumSelectEmptyFilter` picker pattern already used for the status columns, instead of an exact-match text filter.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.