### PR TITLE
chore: override smol-toml to fix high-severity DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19908,9 +19908,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "serialize-javascript": "7.0.5",
     "dompurify": "3.4.13",
     "postcss": "8.5.26",
-    "sharp": "0.35.4"
+    "sharp": "0.35.4",
+    "smol-toml": "1.7.1"
   },
   "engines": {
     "node": ">=24.14.0",


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Fixes a high-severity `npm audit` finding: `smol-toml`, bundled inside `nx@23.1.1`, is vulnerable to a DoS via malformed TOML (GHSA-7w5x-hrqm-74c2). No `nx` release fixes this yet, so added `"smol-toml": "1.7.1"` to `overrides` and regenerated the lockfile.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.