### PR TITLE
feat: add filter-aware CSV export button to Grade C grid

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/export/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/[id]/discovery-datasets/export/route.ts
@@ -1,0 +1,26 @@
+import { channelsApi } from '@/src/app/api/api';
+import { getRequestToken } from '@/src/utils/auth/get-token';
+import { guardDiscoveryDatasetsEnabled } from '@/src/server/feature-flag-guard';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const disabled = guardDiscoveryDatasetsEnabled();
+  if (disabled) return disabled;
+
+  try {
+    const params = await context.params;
+    const search = new URL(req.url).searchParams;
+    const token = await getRequestToken(req);
+    return await channelsApi.exportChannelDiscoveryDatasets(params.id, token, {
+      agency: search.get('agency') ?? undefined,
+      validation_status: search.get('validation_status') ?? undefined,
+      indexing_status: search.get('indexing_status') ?? undefined,
+    });
+  } catch {
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/DiscoveryDatasetsView.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { GridOptions } from 'ag-grid-community';
 import {
   IconFileArrowLeft,
+  IconFileArrowRight,
   IconRefreshDot,
   IconTrash,
 } from '@tabler/icons-react';
@@ -65,6 +66,7 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   const [showDeleteSelectedConfirm, setShowDeleteSelectedConfirm] =
     useState(false);
   const [showClearAllConfirm, setShowClearAllConfirm] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   usePageInitialLoadingSync(isInitialLoading);
   const [stats, setStats] = useState<DiscoveryDatasetStats | null>(null);
@@ -108,45 +110,51 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
   );
 
   const deleteSelected = useCallback(() => {
+    setIsMutating(true);
     withNotification(
       sendDeleteRequest<{ item_ids: number[] }, string>(
         DISCOVERY_DATASETS_BULK_URL,
         { item_ids: selectedIds },
       ),
       'Failed to Delete Selected Grade C Datasets',
-    ).then((result) => {
-      if (result.ok) {
-        const deletedCount = (JSON.parse(result.data) as DiscoveryDataset[])
-          .length;
-        setSelectedIds([]);
-        setRefreshToken((x) => x + 1);
-        showNotification({
-          type: NotificationType.success,
-          title: 'Grade C Dataset Records Deleted',
-          description: `Deleted ${deletedCount} Grade C dataset record${deletedCount === 1 ? '' : 's'}`,
-        });
-      }
-    });
+    )
+      .then((result) => {
+        if (result.ok) {
+          const deletedCount = (JSON.parse(result.data) as DiscoveryDataset[])
+            .length;
+          setSelectedIds([]);
+          setRefreshToken((x) => x + 1);
+          showNotification({
+            type: NotificationType.success,
+            title: 'Grade C Dataset Records Deleted',
+            description: `Deleted ${deletedCount} Grade C dataset record${deletedCount === 1 ? '' : 's'}`,
+          });
+        }
+      })
+      .finally(() => setIsMutating(false));
   }, [withNotification, selectedIds, showNotification]);
 
   const clearAllDatasets = useCallback(() => {
+    setIsMutating(true);
     withNotification(
       sendDeleteRequest<object, string>(
         CHANNEL_DISCOVERY_DATASETS_BULK_URL(selectedChannelId),
       ),
       'Failed to Clear Grade C Datasets',
-    ).then((result) => {
-      if (result.ok) {
-        const deletedCount = (JSON.parse(result.data) as DiscoveryDataset[])
-          .length;
-        setRefreshToken((x) => x + 1);
-        showNotification({
-          type: NotificationType.success,
-          title: 'Grade C Dataset Records Deleted',
-          description: `Deleted ${deletedCount} Grade C dataset record${deletedCount === 1 ? '' : 's'}`,
-        });
-      }
-    });
+    )
+      .then((result) => {
+        if (result.ok) {
+          const deletedCount = (JSON.parse(result.data) as DiscoveryDataset[])
+            .length;
+          setRefreshToken((x) => x + 1);
+          showNotification({
+            type: NotificationType.success,
+            title: 'Grade C Dataset Records Deleted',
+            description: `Deleted ${deletedCount} Grade C dataset record${deletedCount === 1 ? '' : 's'}`,
+          });
+        }
+      })
+      .finally(() => setIsMutating(false));
   }, [withNotification, selectedChannelId, showNotification]);
 
   const deleteRow = useCallback(
@@ -225,6 +233,12 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
     [fetchDiscoveryDatasetsPage, refreshToken],
   );
 
+  const currentFiltersRef = useRef<{
+    agency?: string;
+    validation_status?: string;
+    indexing_status?: string;
+  }>({});
+
   const fetchRows = useCallback(
     (args: FetchRowsArgs): Promise<FetchRowsResult<DiscoveryDataset>> => {
       const agency = getEnumFilterValue(args.filterModel, 'agency');
@@ -237,6 +251,12 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
         'indexingStatus',
       );
 
+      currentFiltersRef.current = {
+        agency,
+        validation_status,
+        indexing_status,
+      };
+
       return fetchDiscoveryDatasetsPageMemoized({
         limit: args.limit,
         offset: args.offset,
@@ -248,6 +268,21 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
     [fetchDiscoveryDatasetsPageMemoized],
   );
 
+  const exportDatasets = useCallback(() => {
+    const filters = currentFiltersRef.current;
+    const query = new URLSearchParams();
+    if (filters.agency) query.set('agency', filters.agency);
+    if (filters.validation_status)
+      query.set('validation_status', filters.validation_status);
+    if (filters.indexing_status)
+      query.set('indexing_status', filters.indexing_status);
+
+    const url = `/api/v1/channels/${selectedChannelId}/discovery-datasets/export${
+      query.toString() ? `?${query}` : ''
+    }`;
+    window.open(url, '_blank');
+  }, [selectedChannelId]);
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex flex-row items-center justify-between mb-3">
@@ -257,28 +292,37 @@ export const DiscoveryDatasetsView: FC<Props> = ({ selectedChannelId }) => {
             cssClass="secondary"
             title="Reindex"
             icon={<IconRefreshDot {...BASE_ICON_PROPS} />}
-            disable={isReindexInProgress}
+            disable={isReindexInProgress || isMutating || !stats?.total}
             onClick={() => setShowReindexConfirm(true)}
           />
           <Button
             cssClass="primary ml-3"
             title="Upload"
             icon={<IconFileArrowLeft {...BASE_ICON_PROPS} />}
-            disable={isReindexInProgress}
+            disable={isReindexInProgress || isMutating}
             onClick={() => setShowUploadModal(true)}
+          />
+          <Button
+            cssClass="secondary ml-3"
+            title="Export"
+            icon={<IconFileArrowRight {...BASE_ICON_PROPS} />}
+            disable={isReindexInProgress || isMutating || !stats?.total}
+            onClick={exportDatasets}
           />
           <Button
             cssClass="secondary ml-3 min-w-[185px] justify-center"
             title={`Delete selected (${selectedIds.length})`}
             icon={<IconTrash {...BASE_ICON_PROPS} />}
-            disable={selectedIds.length === 0}
+            disable={
+              isReindexInProgress || isMutating || selectedIds.length === 0
+            }
             onClick={() => setShowDeleteSelectedConfirm(true)}
           />
           <Button
             cssClass="secondary ml-3"
             title="Clear all"
             icon={<IconTrash {...BASE_ICON_PROPS} />}
-            disable={isReindexInProgress || !stats?.total}
+            disable={isReindexInProgress || isMutating || !stats?.total}
             onClick={() => setShowClearAllConfirm(true)}
           />
         </div>

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -56,6 +56,10 @@ export const CHANNEL_DISCOVERY_DATASETS_STATS_URL = (
   id?: string | number,
 ): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/stats`;
 
+export const CHANNEL_DISCOVERY_DATASETS_EXPORT_URL = (
+  id?: string | number,
+): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/export`;
+
 export const CHANNEL_DISCOVERY_INDEXING_JOBS_URL = (
   id?: string | number,
 ): string => `${CHANNEL_DISCOVERY_DATASETS_URL(id)}/indexing-jobs`;
@@ -442,6 +446,25 @@ export class ChannelsApi extends BaseApi {
     token: JWT | null,
   ): Promise<ApiResult<DiscoveryDatasetStats>> {
     return this.get(CHANNEL_DISCOVERY_DATASETS_STATS_URL(id), token);
+  }
+
+  exportChannelDiscoveryDatasets(
+    id: string,
+    token: JWT | null,
+    filters?: {
+      agency?: string;
+      validation_status?: string;
+      indexing_status?: string;
+    },
+  ) {
+    const searchParams = new URLSearchParams();
+    Object.entries(filters ?? {}).forEach(([key, value]) => {
+      if (value) searchParams.set(key, value);
+    });
+
+    const url = CHANNEL_DISCOVERY_DATASETS_EXPORT_URL(id);
+    const query = searchParams.toString();
+    return this.streamRequest(query ? `${url}?${query}` : url, token);
   }
 
   uploadChannelDiscoveryDatasets(


### PR DESCRIPTION
### Applicable issues

- #255
- https://github.com/epam/statgpt-admin-frontend/issues/264

### Description of changes

Adds an "Export" button to the Grade C (discovery datasets) view. Clicking it exports Grade C dataset records to CSV via the existing backend `discovery-datasets/export` endpoint, applying whatever filters (`agency`, `validation_status`, `indexing_status`) are currently active in the grid — the same one-click pattern used by the Audit Logs export button, no confirmation popup.

Also disables all Grade C toolbar buttons (Reindex, Upload, Export, Delete selected, Clear all) while a reindex or a delete/clear-all mutation is in flight, and disables Reindex/Export/Clear all when there are no datasets.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)