### PR TITLE
feat: add replace-mode toggles with confirmation to channel import and Grade C upload

### DIFF
--- a/apps/statgpt-admin-frontend/src/app/api/v1/channels/import/route.ts
+++ b/apps/statgpt-admin-frontend/src/app/api/v1/channels/import/route.ts
@@ -1,8 +1,15 @@
 import { getRequestToken } from '@/src/utils/auth/get-token';
 import { channelsApi } from '@/src/app/api/api';
 import { apiResultToResponse } from '@/src/server/api';
+import { DiscoveryUploadMode } from '@/src/models/discovery-dataset';
 
 export const runtime = 'nodejs';
+
+function parseRecordUploadMode(value: string | null): DiscoveryUploadMode {
+  return value === DiscoveryUploadMode.Replace
+    ? DiscoveryUploadMode.Replace
+    : DiscoveryUploadMode.Upsert;
+}
 
 export async function POST(req: Request) {
   try {
@@ -11,6 +18,12 @@ export async function POST(req: Request) {
     const updateDatasets = search.get('updateDatasets') === 'true';
     const updateDataSources = search.get('updateDataSources') === 'true';
     const cleanUp = search.get('cleanUp') === 'true';
+    const discoveryDatasetsMode = parseRecordUploadMode(
+      search.get('discoveryDatasetsMode'),
+    );
+    const glossaryTermsMode = parseRecordUploadMode(
+      search.get('glossaryTermsMode'),
+    );
     const token = await getRequestToken(req);
     return apiResultToResponse(
       await channelsApi.importChannel(
@@ -18,6 +31,8 @@ export async function POST(req: Request) {
         updateDatasets,
         updateDataSources,
         cleanUp,
+        discoveryDatasetsMode,
+        glossaryTermsMode,
         token,
       ),
     );

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.test.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.test.tsx
@@ -46,7 +46,6 @@ describe('UploadModal', () => {
         unchanged: 0,
         deleted: 0,
         rowsRead: 0,
-        rowsSkipped: 0,
       },
     });
   });

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.test.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+/* global describe, it, expect, jest, beforeEach */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { sendPostRequest } from '@/src/server/api';
+import { UploadModal } from './UploadModal';
+
+jest.mock('@/src/components/BaseComponents/LoadFileArea/LoadFileArea', () => ({
+  __esModule: true,
+  LoadFileAreaField: ({
+    onChangeFile,
+  }: {
+    onChangeFile: (files?: FileList) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onChangeFile([new File([], 'test.csv')] as unknown as FileList)
+      }
+    >
+      select file
+    </button>
+  ),
+}));
+
+jest.mock('@/src/server/api', () => ({
+  sendPostRequest: jest.fn(),
+}));
+
+const mockedSendPostRequest = sendPostRequest as jest.Mock;
+
+const toggleSwitch = (switchId: string): void => {
+  fireEvent.click(document.getElementById(switchId) as HTMLInputElement);
+};
+
+const renderModal = () =>
+  render(<UploadModal channelId="42" close={() => {}} onUploaded={() => {}} />);
+
+describe('UploadModal', () => {
+  beforeEach(() => {
+    mockedSendPostRequest.mockReset();
+    mockedSendPostRequest.mockResolvedValue({
+      ok: true,
+      data: {
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        deleted: 0,
+        rowsRead: 0,
+        rowsSkipped: 0,
+      },
+    });
+  });
+
+  it('uploads immediately when replace is off', async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => expect(mockedSendPostRequest).toHaveBeenCalled());
+    expect(mockedSendPostRequest.mock.calls[0][0]).toContain('mode=upsert');
+    expect(screen.queryByText(/permanently delete/i)).toBeNull();
+  });
+
+  it('shows a confirm step instead of uploading when replace is on', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+    toggleSwitch('upload-replace');
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    expect(screen.getByText(/permanently delete/i)).toBeTruthy();
+    expect(mockedSendPostRequest).not.toHaveBeenCalled();
+  });
+
+  it('uploads with replace mode after confirming', async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+    toggleSwitch('upload-replace');
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Upload' }));
+
+    await waitFor(() => expect(mockedSendPostRequest).toHaveBeenCalled());
+    expect(mockedSendPostRequest.mock.calls[0][0]).toContain('mode=replace');
+  });
+
+  it('returns to the select step on Back without uploading', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+    toggleSwitch('upload-replace');
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(screen.getByRole('button', { name: 'Upload' })).toBeTruthy();
+    expect(mockedSendPostRequest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
@@ -29,7 +29,6 @@ const SUMMARY_LABELS: { key: keyof DiscoveryUploadSummary; label: string }[] = [
   { key: 'unchanged', label: 'Unchanged' },
   { key: 'deleted', label: 'Deleted' },
   { key: 'rowsRead', label: 'Rows Read' },
-  { key: 'rowsSkipped', label: 'Rows Skipped' },
 ];
 
 export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {

--- a/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/DiscoveryDatasetsView/UploadModal/UploadModal.tsx
@@ -3,9 +3,9 @@
 import { FC, useState } from 'react';
 
 import { Button } from '@/src/components/BaseComponents/Button/Button';
-import Checkbox from '@/src/components/BaseComponents/Checkbox/Checkbox';
 import { LoadFileAreaField } from '@/src/components/BaseComponents/LoadFileArea/LoadFileArea';
 import LoaderSmall from '@/src/components/BaseComponents/Loader/Loader';
+import Switch from '@/src/components/BaseComponents/Switch/Switch';
 import { Modal } from '@/src/components/Modal/Modal';
 import {
   DiscoveryPayloadErrorResponse,
@@ -15,7 +15,7 @@ import {
 } from '@/src/models/discovery-dataset';
 import { sendPostRequest } from '@/src/server/api';
 
-type Step = 'select' | 'uploading' | 'success' | 'error';
+type Step = 'select' | 'confirm' | 'uploading' | 'success' | 'error';
 
 interface Props {
   channelId: string;
@@ -35,7 +35,7 @@ const SUMMARY_LABELS: { key: keyof DiscoveryUploadSummary; label: string }[] = [
 export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
   const [step, setStep] = useState<Step>('select');
   const [files, setFiles] = useState<FileList | undefined>(void 0);
-  const [deleteAbsent, setDeleteAbsent] = useState(false);
+  const [replace, setReplace] = useState(false);
   const [summary, setSummary] = useState<DiscoveryUploadSummary | undefined>(
     void 0,
   );
@@ -46,7 +46,7 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
     if (!files) return;
     setStep('uploading');
 
-    const mode = deleteAbsent
+    const mode = replace
       ? DiscoveryUploadMode.Replace
       : DiscoveryUploadMode.Upsert;
     const formData = new FormData();
@@ -71,6 +71,14 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
     setStep('error');
   };
 
+  const onUploadClick = (): void => {
+    if (replace) {
+      setStep('confirm');
+    } else {
+      upload();
+    }
+  };
+
   const finish = () => {
     onUploaded();
     close();
@@ -78,7 +86,7 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
 
   const handleFilesChange = (newFiles: FileList | undefined) => {
     setFiles(newFiles);
-    if (!newFiles) setDeleteAbsent(false);
+    if (!newFiles) setReplace(false);
   };
 
   return (
@@ -100,23 +108,26 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
             />
 
             {files && (
-              <div className="flex flex-col gap-2">
-                <Checkbox
-                  id="upload-delete-absent"
-                  label="Also delete records not in this file"
-                  checked={deleteAbsent}
-                  onChange={(value) => setDeleteAbsent(!!value)}
-                />
-                <p className="whitespace-pre-wrap text-sm text-secondary">
-                  Records present in the channel but missing from the uploaded
-                  file will be permanently deleted.
-                </p>
-              </div>
+              <Switch
+                isOn={replace}
+                title="Replace records not in this file"
+                switchId="upload-replace"
+                onChange={setReplace}
+              />
             )}
           </>
         )}
 
-        {step === 'uploading' && <LoaderSmall containerClassName="h-[150px]" />}
+        {step === 'confirm' && (
+          <p className="text-sm text-primary">
+            This will permanently delete records present in the channel but
+            missing from the uploaded file.
+          </p>
+        )}
+
+        {step === 'uploading' && (
+          <LoaderSmall size={32} containerClassName="h-[150px]" />
+        )}
 
         {step === 'success' && summary && (
           <div className="flex flex-col gap-y-2">
@@ -182,6 +193,22 @@ export const UploadModal: FC<Props> = ({ channelId, close, onUploaded }) => {
             <Button
               cssClass="primary"
               title="Upload"
+              disable={files == null}
+              onClick={onUploadClick}
+            />
+          </>
+        )}
+
+        {step === 'confirm' && (
+          <>
+            <Button
+              cssClass="secondary mr-3"
+              title="Back"
+              onClick={() => setStep('select')}
+            />
+            <Button
+              cssClass="primary"
+              title="Confirm Upload"
               disable={files == null}
               onClick={upload}
             />

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ImportChannelModal.test.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ImportChannelModal.test.tsx
@@ -1,0 +1,113 @@
+/** @jest-environment jsdom */
+/* global describe, it, expect, jest */
+import { ComponentProps } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { FeatureFlagsProvider } from '@/src/context/FeatureFlagsContext';
+import { ImportChannelModal } from './ImportChannelModal';
+
+jest.mock('@/src/components/BaseComponents/LoadFileArea/LoadFileArea', () => ({
+  __esModule: true,
+  default: ({ onChangeFile }: { onChangeFile: (files?: FileList) => void }) => (
+    <button
+      onClick={() =>
+        onChangeFile([new File([], 'test.csv')] as unknown as FileList)
+      }
+    >
+      select file
+    </button>
+  ),
+}));
+
+type UploadFile = ComponentProps<typeof ImportChannelModal>['uploadFile'];
+
+const renderModal = (
+  discoveryDatasets: boolean,
+  uploadFile: UploadFile = () => {},
+) =>
+  render(
+    <FeatureFlagsProvider flags={{ discoveryDatasets }}>
+      <ImportChannelModal close={() => {}} uploadFile={uploadFile} />
+    </FeatureFlagsProvider>,
+  );
+
+const toggleSwitch = (switchId: string): void => {
+  fireEvent.click(document.getElementById(switchId) as HTMLInputElement);
+};
+
+describe('ImportChannelModal', () => {
+  describe('when Grade C datasets are disabled', () => {
+    it('does not render the discovery datasets replace switch', () => {
+      renderModal(false);
+
+      expect(screen.queryByText('Replace Grade C datasets')).toBeNull();
+    });
+
+    it('still renders the glossary terms replace switch', () => {
+      renderModal(false);
+
+      expect(screen.getByText('Replace glossary terms')).toBeTruthy();
+    });
+  });
+
+  describe('when Grade C datasets are enabled', () => {
+    it('renders the discovery datasets replace switch', () => {
+      renderModal(true);
+
+      expect(screen.getByText('Replace Grade C datasets')).toBeTruthy();
+    });
+  });
+
+  describe('confirm step', () => {
+    it('submits immediately when neither replace switch is on', () => {
+      const uploadFile = jest.fn();
+      renderModal(false, uploadFile);
+
+      fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+      expect(uploadFile).toHaveBeenCalled();
+      expect(screen.queryByText(/permanently delete/i)).toBeNull();
+    });
+
+    it('shows what will be deleted instead of submitting when a replace switch is on', () => {
+      const uploadFile = jest.fn();
+      renderModal(false, uploadFile);
+
+      toggleSwitch('replaceGlossaryTerms');
+      fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+      expect(screen.getByText(/permanently delete/i)).toBeTruthy();
+      expect(
+        screen.getByText('Glossary terms not in this archive'),
+      ).toBeTruthy();
+      expect(uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('submits after Confirm Import is clicked', () => {
+      const uploadFile = jest.fn();
+      renderModal(false, uploadFile);
+
+      toggleSwitch('replaceGlossaryTerms');
+      fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }));
+
+      expect(uploadFile).toHaveBeenCalled();
+    });
+
+    it('returns to the select step on Back without submitting', () => {
+      const uploadFile = jest.fn();
+      renderModal(false, uploadFile);
+
+      toggleSwitch('replaceGlossaryTerms');
+      fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+      expect(screen.getByRole('button', { name: 'Import' })).toBeTruthy();
+      expect(uploadFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ImportChannelModal.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ImportChannelModal.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/src/components/BaseComponents/Button/Button';
 import LoadFileAreaField from '@/src/components/BaseComponents/LoadFileArea/LoadFileArea';
 import Switch from '@/src/components/BaseComponents/Switch/Switch';
 import { Modal } from '@/src/components/Modal/Modal';
+import { useFeatureFlags } from '@/src/context/FeatureFlagsContext';
+import { DiscoveryUploadMode } from '@/src/models/discovery-dataset';
 
 interface Props {
   close: () => void;
@@ -12,17 +14,45 @@ interface Props {
     updateDatasets: boolean,
     updateDataSources: boolean,
     cleanUp: boolean,
+    discoveryDatasetsMode: DiscoveryUploadMode,
+    glossaryTermsMode: DiscoveryUploadMode,
   ) => void;
 }
 
+type Step = 'select' | 'confirm';
+
 export const ImportChannelModal: FC<Props> = ({ close, uploadFile }) => {
+  const { discoveryDatasets } = useFeatureFlags();
+  const [step, setStep] = useState<Step>('select');
   const [updateDatasets, setIsUpdateDatasets] = useState(false);
   const [updateDataSources, setIsUpdateDataSources] = useState(false);
   const [cleanUp, setCleanUp] = useState(false);
+  const [replaceDiscoveryDatasets, setReplaceDiscoveryDatasets] =
+    useState(false);
+  const [replaceGlossaryTerms, setReplaceGlossaryTerms] = useState(false);
   const [files, setFiles] = useState<FileList | undefined>(void 0);
 
   const importChannel = (): void => {
-    uploadFile?.(files as FileList, updateDatasets, updateDataSources, cleanUp);
+    uploadFile?.(
+      files as FileList,
+      updateDatasets,
+      updateDataSources,
+      cleanUp,
+      replaceDiscoveryDatasets
+        ? DiscoveryUploadMode.Replace
+        : DiscoveryUploadMode.Upsert,
+      replaceGlossaryTerms
+        ? DiscoveryUploadMode.Replace
+        : DiscoveryUploadMode.Upsert,
+    );
+  };
+
+  const onImportClick = (): void => {
+    if (replaceDiscoveryDatasets || replaceGlossaryTerms) {
+      setStep('confirm');
+    } else {
+      importChannel();
+    }
   };
 
   const handleFileInput = (files?: FileList): void => {
@@ -50,11 +80,62 @@ export const ImportChannelModal: FC<Props> = ({ close, uploadFile }) => {
     [setCleanUp],
   );
 
+  const onSwitchReplaceDiscoveryDatasets = useCallback(
+    (value: boolean) => {
+      setReplaceDiscoveryDatasets(value);
+    },
+    [setReplaceDiscoveryDatasets],
+  );
+
+  const onSwitchReplaceGlossaryTerms = useCallback(
+    (value: boolean) => {
+      setReplaceGlossaryTerms(value);
+    },
+    [setReplaceGlossaryTerms],
+  );
+
+  if (step === 'confirm') {
+    return (
+      <Modal title="Import Channel" close={close}>
+        <></>
+
+        <div className="flex flex-col gap-y-4 h-[400px] p-4">
+          <p className="text-primary">
+            This will permanently delete records not present in the imported
+            archive:
+          </p>
+          <ul className="list-disc pl-5 text-secondary">
+            {replaceDiscoveryDatasets && (
+              <li>Grade C datasets not in this archive</li>
+            )}
+            {replaceGlossaryTerms && (
+              <li>Glossary terms not in this archive</li>
+            )}
+          </ul>
+        </div>
+
+        <div className="flex flex-row justify-end">
+          <Button
+            cssClass="secondary mr-3"
+            title="Back"
+            onClick={() => setStep('select')}
+          />
+          <Button
+            cssClass="primary"
+            title="Confirm Import"
+            disable={files == null}
+            onClick={() => importChannel()}
+          />
+        </div>
+      </Modal>
+    );
+  }
+
   return (
     <Modal title="Import Channel" close={close}>
       <></>
 
-      <div className="flex flex-col gap-y-6 h-[300px] p-4">
+      <div className="flex flex-col gap-y-6 h-[400px] p-4">
         <LoadFileAreaField
           elementId="file"
           acceptTypes=""
@@ -83,6 +164,22 @@ export const ImportChannelModal: FC<Props> = ({ close, uploadFile }) => {
           switchId="updateDataSources"
           onChange={onSwitchDataSource}
         />
+
+        {discoveryDatasets && (
+          <Switch
+            isOn={replaceDiscoveryDatasets}
+            title={'Replace Grade C datasets'}
+            switchId="replaceDiscoveryDatasets"
+            onChange={onSwitchReplaceDiscoveryDatasets}
+          />
+        )}
+
+        <Switch
+          isOn={replaceGlossaryTerms}
+          title={'Replace glossary terms'}
+          switchId="replaceGlossaryTerms"
+          onChange={onSwitchReplaceGlossaryTerms}
+        />
       </div>
 
       <div className="flex flex-row justify-end">
@@ -95,7 +192,7 @@ export const ImportChannelModal: FC<Props> = ({ close, uploadFile }) => {
           cssClass="primary"
           title="Import"
           disable={files == null}
-          onClick={() => importChannel()}
+          onClick={() => onImportClick()}
         />
       </div>
     </Modal>

--- a/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ListHeader.tsx
+++ b/apps/statgpt-admin-frontend/src/components/ListView/ListHeader/ListHeader.tsx
@@ -9,6 +9,9 @@ import { IconFileArrowLeft, IconPlus } from '@tabler/icons-react';
 import { Button } from '@/src/components/BaseComponents/Button/Button';
 import { Menu } from '@/src/constants/menu';
 import { BASE_ICON_PROPS } from '@/src/constants/layout';
+import { useNotification } from '@/src/context/NotificationContext';
+import { DiscoveryUploadMode } from '@/src/models/discovery-dataset';
+import { NotificationType } from '@/src/models/notification';
 import { AddEntityModal } from '../AddEntityModal';
 import { ImportChannelModal } from './ImportChannelModal';
 import { sendPostRequest } from '../../../server/api';
@@ -25,25 +28,41 @@ export const ListHeader: FC<Props> = ({ title, count }) => {
 
   const router = useRouter();
   const withNotification = useApiNotification();
+  const { showNotification, removeNotification } = useNotification();
 
   const uploadFile = (
     files: FileList,
     updateDatasets: boolean,
     updateDataSources: boolean,
     cleanUp: boolean,
+    discoveryDatasetsMode: DiscoveryUploadMode,
+    glossaryTermsMode: DiscoveryUploadMode,
   ) => {
     setShowImportModal(false);
     const formData = new FormData();
     formData.append('file', files[0], files[0].name);
 
+    const loadingNotificationId = showNotification({
+      type: NotificationType.loading,
+      title: 'Importing channel',
+      description: 'Import is in progress. This may take a few minutes.',
+      duration: null,
+    });
+
     withNotification(
       sendPostRequest(
-        `/api/v1/channels/import?updateDatasets=${updateDatasets}&updateDataSources=${updateDataSources}&cleanUp=${cleanUp}`,
+        `/api/v1/channels/import?updateDatasets=${updateDatasets}&updateDataSources=${updateDataSources}&cleanUp=${cleanUp}&discoveryDatasetsMode=${discoveryDatasetsMode}&glossaryTermsMode=${glossaryTermsMode}`,
         formData,
       ),
       'Import Failed',
     ).then((result) => {
+      removeNotification(loadingNotificationId);
       if (result.ok) {
+        showNotification({
+          type: NotificationType.success,
+          title: 'Import complete',
+          description: 'Channel imported successfully.',
+        });
         router.refresh();
       }
     });

--- a/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
+++ b/apps/statgpt-admin-frontend/src/models/discovery-dataset.ts
@@ -87,7 +87,6 @@ export interface DiscoveryUploadSummary {
   unchanged: number;
   deleted: number;
   rowsRead: number;
-  rowsSkipped: number;
 }
 
 export interface DiscoveryPayloadProblem {

--- a/apps/statgpt-admin-frontend/src/server/channels-api.ts
+++ b/apps/statgpt-admin-frontend/src/server/channels-api.ts
@@ -174,10 +174,12 @@ export class ChannelsApi extends BaseApi {
     updateDatasets: boolean,
     updateDataSources: boolean,
     cleanUp: boolean,
+    discoveryDatasetsMode: DiscoveryUploadMode,
+    glossaryTermsMode: DiscoveryUploadMode,
     token: JWT | null,
   ): Promise<ApiResult<null>> {
     const initResult = await this.post(
-      `${CHANNELS_IMPORT_URL}?update_data_sources=${updateDataSources}&update_datasets=${updateDatasets}&clean_up=${cleanUp}`,
+      `${CHANNELS_IMPORT_URL}?update_data_sources=${updateDataSources}&update_datasets=${updateDatasets}&clean_up=${cleanUp}&discovery_datasets_mode=${discoveryDatasetsMode}&glossary_terms_mode=${glossaryTermsMode}`,
       formData,
       void 0,
       void 0,


### PR DESCRIPTION
### Applicable issues

- #256

### Description of changes

Channel import popup gains two new switches — "Replace Grade C datasets" (gated behind `ENABLE_DISCOVERY_DATASETS`) and "Replace glossary terms" — that toggle the backend's new `discovery_datasets_mode`/`glossary_terms_mode` upsert/replace query params on `POST /channels/import`.

Because "replace" can permanently delete records, both this modal and the Grade C "Upload" modal now show an in-modal confirmation step (no separate popup) before submitting whenever a replace switch is on, listing exactly what will be deleted. The Grade C upload modal's "Also delete records not in this file" checkbox is reworked into a toggle switch to match, and its in-flight loader is bumped slightly larger.

The channel import flow also gains a persistent "Importing channel" toast while the request is in flight (it can take several minutes) and a new success toast on completion — previously only failures were surfaced.

Also removes the `rowsSkipped` field from the Grade C upload summary, following its removal on the backend in epam/statgpt-backend#665 (not yet merged).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.